### PR TITLE
feat: create set deployment image attack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ go.docker.mod
 /e2e/e2e-coverage-docker.out
 /licenses
 /snyk.sarif
+/vendor
 

--- a/client/permissions.go
+++ b/client/permissions.go
@@ -2,11 +2,14 @@ package client
 
 import (
 	"context"
+
 	"github.com/rs/zerolog/log"
 	"github.com/steadybit/extension-kubernetes/v2/extconfig"
 	authorizationv1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+
+	authorizationv1 "k8s.io/api/authorization/v1"
 )
 
 type PermissionCheckResult struct {
@@ -216,9 +219,17 @@ func (p *PermissionCheckResult) IsTaintNodePermitted() bool {
 		"nodes/patch",
 	})
 }
+
 func (p *PermissionCheckResult) IsCrashLoopPodPermitted() bool {
 	return p.hasPermissions([]string{
 		"pods/exec/create",
+	})
+}
+
+func (p *PermissionCheckResult) IsSetImagePermitted() bool {
+	return p.hasPermissions([]string{
+		"apps/deployments/get",
+		"apps/deployments/patch",
 	})
 }
 

--- a/extdeployment/attack_set_image.go
+++ b/extdeployment/attack_set_image.go
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025 Steadybit GmbH
+
+package extdeployment
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/steadybit/action-kit/go/action_kit_api/v2"
+	"github.com/steadybit/action-kit/go/action_kit_sdk"
+	extension_kit "github.com/steadybit/extension-kit"
+	"github.com/steadybit/extension-kit/extbuild"
+	"github.com/steadybit/extension-kit/extconversion"
+	"github.com/steadybit/extension-kit/extutil"
+	"github.com/steadybit/extension-kubernetes/v2/client"
+	"github.com/steadybit/extension-kubernetes/v2/extcommon"
+)
+
+func NewSetImageAction() action_kit_sdk.Action[extcommon.KubectlActionState] {
+	return &extcommon.KubectlAction{
+		Description:  getSetImageDescription(),
+		OptsProvider: setImage(),
+	}
+}
+
+type SetImageConfig struct {
+	Image         string `json:"image"`
+	ContainerName string `json:"container_name"`
+}
+
+func getSetImageDescription() action_kit_api.ActionDescription {
+	return action_kit_api.ActionDescription{
+		Id:          SetImageActionId,
+		Label:       "Set Image",
+		Description: "Set Image for Kubernetes Deployment",
+		Version:     extbuild.GetSemverVersionStringOrUnknown(),
+		// TODO: update icon
+		Icon:       extutil.Ptr("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0yMC4xMSAxNS41SDE4LjM2QzE3Ljk1IDE1LjUgMTcuNjEgMTUuMTYgMTcuNjEgMTQuNzVDMTcuNjEgMTQuMzQgMTcuOTUgMTQgMTguMzYgMTRIMjAuMTFDMjAuOCAxNCAyMS4zNiAxMy40NCAyMS4zNiAxMi43NVY0Ljc1QzIxLjM2IDQuMDYgMjAuOCAzLjUgMjAuMTEgMy41SDkuMTA5OTlDOC40MTk5OSAzLjUgNy44NTk5OSA0LjA2IDcuODU5OTkgNC43NVY1LjkzQzcuODU5OTkgNi4zNCA3LjUxOTk5IDYuNjggNy4xMDk5OSA2LjY4QzYuNjk5OTkgNi42OCA2LjM1OTk5IDYuMzQgNi4zNTk5OSA1LjkzVjQuNzVDNi4zNTk5OSAzLjIzIDcuNTg5OTkgMiA5LjEwOTk5IDJIMjAuMTFDMjEuNjMgMiAyMi44NiAzLjIzIDIyLjg2IDQuNzVWMTIuNzVDMjIuODYgMTQuMjcgMjEuNjMgMTUuNSAyMC4xMSAxNS41Wk0xOS4zNSA1SDE3LjE3QzE2Ljg5IDUgMTYuNjUgNS4yMyAxNi42NSA1LjUyQzE2LjY1IDUuODEgMTYuODggNi4wNCAxNy4xNyA2LjA0SDE4LjFMMTYuNiA3LjUxVjcuNTNMMTQuMDUgMTAuMDVWOS4xMUMxNC4wNSA4LjgzIDEzLjgyIDguNTkgMTMuNTMgOC41OUMxMy4yNCA4LjU5IDEzLjAxIDguODIgMTMuMDEgOS4xMVYxMS4yOUMxMy4wMSAxMS41NyAxMy4yNCAxMS44MSAxMy41MyAxMS44MUgxNS43MUMxNS45OSAxMS44MSAxNi4yMyAxMS41OCAxNi4yMyAxMS4yOUMxNi4yMyAxMSAxNiAxMC43NyAxNS43MSAxMC43N0gxNC43OEwxNy4zMyA4LjI1VjguMjNMMTguODQgNi43NVY3LjY5QzE4Ljg0IDcuOTcgMTkuMDcgOC4yMSAxOS4zNiA4LjIxQzE5LjY1IDguMjEgMTkuODggNy45OCAxOS44OCA3LjY5VjUuNTJDMTkuODggNS4yNCAxOS42NSA1IDE5LjM2IDVIMTkuMzVaTTkuMDM4MTUgMTAuMjE1MkwxMi44OTY1IDEyLjE2NTJWMTIuMTczNkMxMy41NzQ5IDEyLjUyMTIgMTQgMTMuMjE2NCAxNCAxMy45Nzk0VjE5LjAzMjNDMTQgMTkuNzk1MyAxMy41NzQ5IDIwLjQ5OSAxMi44OTY1IDIwLjgzODFMOS4wMzgxNSAyMi43ODhDOC40ODIyOSAyMy4wNjc4IDcuODM2NTEgMjMuMDY3OCA3LjI4MDY1IDIyLjgwNUwzLjE0NDQxIDIwLjgyMTFDMi40NDE0MiAyMC40OTA1IDIgMTkuNzc4MyAyIDE4Ljk5ODRWMTQuMDA0OUMyIDEzLjIyNDkgMi40NDE0MiAxMi41MTI4IDMuMTQ0NDEgMTIuMTgyMUw3LjI4MDY1IDEwLjE5ODNDNy44MzY1MSA5LjkyNjk5IDguNDkwNDYgOS45MzU0NyA5LjAzODE1IDEwLjIxNTJaTTEyLjI5OTcgMTkuNjI1N0MxMi41Mjg2IDE5LjUwNyAxMi42Njc2IDE5LjI3ODEgMTIuNjY3NiAxOS4wMjM4VjE4Ljk5ODRWMTMuOTQ1NUMxMi42Njc2IDEzLjY5MTIgMTIuNTI4NiAxMy40NTM4IDEyLjI5OTcgMTMuMzQzNkw4LjQ0MTQyIDExLjM5MzdDOC4yNTM0MSAxMS4zMDg5IDguMDQwODcgMTEuMzA4OSA3Ljg1Mjg2IDExLjM5MzdMMy43MTY2MiAxMy4zNzc1QzMuNDc5NTYgMTMuNDg3NyAzLjMzMjQyIDEzLjcyNTEgMy4zMzI0MiAxMy45ODc5VjE4Ljk4MTRDMy4zMzI0MiAxOS4yNDQyIDMuNDg3NzQgMTkuNDgxNiAzLjcxNjYyIDE5LjU5MThMNy44NTI4NiAyMS41NzU3QzguMDQwODcgMjEuNjY4OSA4LjI2MTU4IDIxLjY2ODkgOC40NDE0MiAyMS41NzU3TDEyLjI5OTcgMTkuNjI1N1pNOC41ODAzOCAxMy4yNDE5TDEwLjcyMjEgMTQuMjUwN0MxMS4wOTgxIDE0LjQyODggMTEuMzM1MSAxNC43ODQ4IDExLjMzNTEgMTUuMTgzM1YxNy44MDNDMTEuMzM1MSAxOC4xOTMgMTEuMDk4MSAxOC41NTc1IDEwLjcyMjEgMTguNzM1Nkw4LjU4MDM4IDE5Ljc0NDRDOC4yNzc5MyAxOS44ODg2IDcuOTE4MjYgMTkuODg4NiA3LjYwNzYzIDE5Ljc1MjlMNS4zMTA2MyAxOC43MjcxQzQuOTE4MjYgMTguNTU3NSA0LjY3MzAyIDE4LjE5MyA0LjY3MzAyIDE3Ljc4NlYxNS4yMDAzQzQuNjczMDIgMTQuODAxOCA0LjkyNjQzIDE0LjQyODggNS4zMTA2MyAxNC4yNTkyTDcuNjA3NjMgMTMuMjMzNEM3LjkxODI2IDEzLjA5NzcgOC4yNzc5MyAxMy4wOTc3IDguNTgwMzggMTMuMjQxOVoiIGZpbGw9IiMxRDI2MzIiLz4KPC9zdmc+Cg=="),
+		Technology: extutil.Ptr("Kubernetes"),
+		TargetSelection: extutil.Ptr(action_kit_api.TargetSelection{
+			TargetType: DeploymentTargetType,
+			SelectionTemplates: extutil.Ptr([]action_kit_api.TargetSelectionTemplate{
+				{
+					Label:       "Deployment",
+					Description: extutil.Ptr("Find deployment by cluster, namespace, and name"),
+					Query:       "k8s.cluster-name=\"\" AND k8s.namespace=\"\" AND k8s.deployment=\"\"",
+				},
+			}),
+		}),
+		TimeControl: action_kit_api.TimeControlExternal,
+		Kind:        action_kit_api.Attack,
+		Parameters: []action_kit_api.ActionParameter{
+			{
+				Label: "Duration",
+				Description: extutil.Ptr(
+					"The duration of the action. The image will be reverted back to the original value after the action.",
+				),
+				Name:         "duration",
+				Type:         action_kit_api.ActionParameterTypeDuration,
+				DefaultValue: extutil.Ptr("180s"),
+				Required:     extutil.Ptr(true),
+			},
+			{
+				Label: "Container Name",
+				Description: extutil.Ptr(
+					"The name of the container to set the image for.",
+				),
+				Name:     "container_name",
+				Type:     action_kit_api.ActionParameterTypeString,
+				Required: extutil.Ptr(true),
+				Options: extutil.Ptr([]action_kit_api.ParameterOption{
+					action_kit_api.ParameterOptionsFromTargetAttribute{
+						Attribute: "k8s.container.name",
+					},
+				}),
+			},
+			{
+				Label:       "Image",
+				Name:        "image",
+				Description: extutil.Ptr("The new image."),
+				Type:        action_kit_api.ActionParameterTypeString,
+				Required:    extutil.Ptr(true),
+			},
+		},
+		Prepare: action_kit_api.MutatingEndpointReference{},
+		Start:   action_kit_api.MutatingEndpointReference{},
+		Status:  &action_kit_api.MutatingEndpointReferenceWithCallInterval{},
+		Stop:    &action_kit_api.MutatingEndpointReference{},
+	}
+}
+
+func setImage() extcommon.KubectlOptsProvider {
+	return func(
+		ctx context.Context,
+		request action_kit_api.PrepareActionRequestBody,
+	) (*extcommon.KubectlOpts, error) {
+		namespace := request.Target.Attributes["k8s.namespace"][0]
+		deployment := request.Target.Attributes["k8s.deployment"][0]
+
+		var config SetImageConfig
+		if err := extconversion.Convert(request.Config, &config); err != nil {
+			return nil, extension_kit.ToError("Failed to unmarshal the config.", err)
+		}
+
+		container := config.ContainerName
+		if container == "" {
+			return nil, extension_kit.ToError(
+				"Container name is required.", nil,
+			)
+		}
+
+		deploymentDefinition := client.K8S.DeploymentByNamespaceAndName(namespace, deployment)
+
+		if deploymentDefinition == nil {
+			return nil, extension_kit.ToError(fmt.Sprintf("Failed to find deployment %s/%s.", namespace, deployment), nil)
+		}
+
+		if deploymentDefinition.Spec.Template.Spec.Containers == nil {
+			return nil, extension_kit.ToError(fmt.Sprintf(
+				"Failed to find containers spec for deployment %s/%s.",
+				namespace,
+				deployment,
+			), nil)
+		}
+
+		var oldContainerImage string
+
+		for _, c := range deploymentDefinition.Spec.Template.Spec.Containers {
+			if c.Name == container {
+				oldContainerImage = c.Image
+				break
+			}
+		}
+
+		if oldContainerImage == "" {
+			return nil, extension_kit.ToError(fmt.Sprintf(
+				"Failed to find container %s in deployment %s/%s.",
+				container,
+				namespace,
+				deployment,
+			), nil)
+		}
+
+		command := []string{"kubectl",
+			"set",
+			"image",
+			fmt.Sprintf("--namespace=%s", namespace),
+			fmt.Sprintf("deployment/%s", deployment),
+			fmt.Sprintf("%s=%s", container, config.Image),
+		}
+
+		rollbackCommand := []string{"kubectl",
+			"set",
+			"image",
+			fmt.Sprintf("--namespace=%s", namespace),
+			fmt.Sprintf("deployment/%s", deployment),
+			fmt.Sprintf("%s=%s", container, oldContainerImage),
+		}
+
+		return &extcommon.KubectlOpts{
+			Command:         command,
+			RollbackCommand: &rollbackCommand,
+			LogTargetType:   "container",
+			LogTargetName: fmt.Sprintf(
+				"%s/%s/%s",
+				namespace,
+				deployment,
+				container,
+			),
+			LogActionName: "set image",
+		}, nil
+	}
+}

--- a/extdeployment/attack_set_image_test.go
+++ b/extdeployment/attack_set_image_test.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025 Steadybit GmbH
+
+package extdeployment
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/steadybit/action-kit/go/action_kit_api/v2"
+	"github.com/steadybit/extension-kit/extutil"
+	"github.com/steadybit/extension-kubernetes/v2/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSetImagePreparesCommands(t *testing.T) {
+	// Given
+	request := action_kit_api.PrepareActionRequestBody{
+		Config: map[string]interface{}{
+			"duration":       100000,
+			"image":          "nginx:456",
+			"container_name": "cashier",
+		},
+		Target: extutil.Ptr(action_kit_api.Target{
+			Attributes: map[string][]string{
+				"k8s.namespace":      {"demo"},
+				"k8s.deployment":     {"shop"},
+				"k8s.container.name": {"main", "cashier"},
+			},
+		}),
+	}
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	testClient, clientset := getTestClient(stopCh)
+
+	_, err := clientset.
+		AppsV1().
+		Deployments("demo").
+		Create(context.Background(), &appsv1.Deployment{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Deployment",
+				APIVersion: "apps/v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "shop",
+				Namespace: "demo",
+			},
+			Spec: appsv1.DeploymentSpec{
+				Template: v1.PodTemplateSpec{
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name:  "main",
+								Image: "nginx:123",
+							},
+							{
+								Name:  "cashier",
+								Image: "nginx:123",
+							},
+						},
+					},
+				},
+			},
+		}, metav1.CreateOptions{})
+
+	require.NoError(t, err)
+
+	client.K8S = testClient
+
+	assert.Eventually(t, func() bool {
+		return testClient.DeploymentByNamespaceAndName("demo", "shop") != nil
+	}, time.Second, 100*time.Millisecond)
+
+	action := NewSetImageAction()
+	state := action.NewEmptyState()
+
+	// When
+	_, err = action.Prepare(context.Background(), &state, request)
+	require.NoError(t, err)
+
+	// Then
+	require.Equal(
+		t,
+		[]string{
+			"kubectl",
+			"set",
+			"image",
+			"--namespace=demo",
+			"deployment/shop",
+			"cashier=nginx:456",
+		},
+		state.Opts.Command,
+	)
+
+	require.Equal(
+		t,
+		[]string{
+			"kubectl",
+			"set",
+			"image",
+			"--namespace=demo",
+			"deployment/shop",
+			"cashier=nginx:123",
+		},
+		*state.Opts.RollbackCommand,
+	)
+}

--- a/extdeployment/common.go
+++ b/extdeployment/common.go
@@ -10,4 +10,5 @@ const (
 	RolloutRestartActionId          = "com.steadybit.extension_kubernetes.rollout-restart"
 	RolloutStatusActionId           = "com.steadybit.extension_kubernetes.rollout-status"
 	ScaleDeploymentActionId         = "com.steadybit.extension_kubernetes.scale_deployment"
+	SetImageActionId                = "com.steadybit.extension_kubernetes.set_image"
 )

--- a/extdeployment/deployment_discovery_test.go
+++ b/extdeployment/deployment_discovery_test.go
@@ -6,6 +6,10 @@ package extdeployment
 import (
 	"context"
 	"fmt"
+	"sort"
+	"testing"
+	"time"
+
 	"github.com/steadybit/extension-kit/extutil"
 	"github.com/steadybit/extension-kubernetes/v2/client"
 	"github.com/steadybit/extension-kubernetes/v2/extconfig"
@@ -19,9 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
 	testclient "k8s.io/client-go/kubernetes/fake"
-	"sort"
-	"testing"
-	"time"
 )
 
 func Test_deploymentDiscovery(t *testing.T) {
@@ -61,6 +62,7 @@ func Test_deploymentDiscovery(t *testing.T) {
 				"k8s.container.id.stripped":                  {"abcdef-aaaaa", "abcdef-bbbbb"},
 				"k8s.distribution":                           {"kubernetes"},
 				"k8s.specification.has-host-podantiaffinity": {"false"},
+				"k8s.container.name":                         {"nginx", "shop"},
 			},
 		},
 		{

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+
 	_ "github.com/KimMachineGun/automemlimit" // By default, it sets `GOMEMLIMIT` to 90% of cgroup's memory limit.
 	"github.com/rs/zerolog"
 	"github.com/steadybit/action-kit/go/action_kit_api/v2"
@@ -67,11 +68,17 @@ func main() {
 		discovery_kit_sdk.Register(extdeployment.NewDeploymentDiscovery(client.K8S))
 		action_kit_sdk.RegisterAction(extdeployment.NewCheckDeploymentRolloutStatusAction())
 		action_kit_sdk.RegisterAction(extdeployment.NewDeploymentPodCountCheckAction(client.K8S))
+
 		if client.K8S.Permissions().IsRolloutRestartPermitted() {
 			action_kit_sdk.RegisterAction(extdeployment.NewDeploymentRolloutRestartAction())
 		}
+
 		if client.K8S.Permissions().IsScaleDeploymentPermitted() {
 			action_kit_sdk.RegisterAction(extdeployment.NewScaleDeploymentAction())
+		}
+
+		if client.K8S.Permissions().IsSetImagePermitted() {
+			action_kit_sdk.RegisterAction(extdeployment.NewSetImageAction())
 		}
 	}
 


### PR DESCRIPTION
This PR creates a new attack action to override a deployment's image. This can be used to run complex failure modes where a Kubernetes service runs a different image, expressing different behaviour.

We do not yet have the correct icon for the action. This is marked in the PR with a `// TODO` line. I'm not familiar with the standard being used to generate these icons. Can you help us with that, please?

I represent [Okta](https://www.okta.com/) in this contribution. We have signed a corporate CLA.