### PR TITLE
fix: copy attributes by ownership instead of selectors

### DIFF
--- a/extdaemonset/daemonset_discovery.go
+++ b/extdaemonset/daemonset_discovery.go
@@ -100,7 +100,7 @@ func (d *daemonSetDiscovery) DiscoverTargets(_ context.Context) ([]discovery_kit
 
 		extcommon.MergeAttributes(
 			attributes,
-			extcommon.GetPodBasedAttributes("daemonset", ds.ObjectMeta, d.k8s.PodsByLabelSelector(ds.Spec.Selector, ds.Namespace), nodes),
+			extcommon.GetPodBasedAttributes("daemonset", ds.ObjectMeta, d.k8s.PodsByOwnerUid(ds.UID, ds.Namespace), nodes),
 			extcommon.GetServiceNames(d.k8s.ServicesMatchingToPodLabels(ds.Namespace, ds.Spec.Template.Labels)),
 		)
 

--- a/extdaemonset/daemonset_discovery_test.go
+++ b/extdaemonset/daemonset_discovery_test.go
@@ -288,6 +288,14 @@ func testPod(nameSuffix string, modifier func(*corev1.Pod)) *corev1.Pod {
 			Labels: map[string]string{
 				"best-city": "kevelaer",
 			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "DaemonSet",
+					Name:       "shop",
+					UID:        "daemonset-shop-uid",
+				},
+			},
 		},
 		Status: corev1.PodStatus{
 			Phase: corev1.PodRunning,
@@ -318,6 +326,7 @@ func testDaemonSet(modifier func(*appsv1.DaemonSet)) *appsv1.DaemonSet {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "shop",
 			Namespace: "default",
+			UID:       "daemonset-shop-uid",
 			Labels: map[string]string{
 				"best-city":    "Kevelaer",
 				"secret-label": "secret-value",

--- a/extdeployment/deployment_discovery.go
+++ b/extdeployment/deployment_discovery.go
@@ -110,7 +110,7 @@ func (d *deploymentDiscovery) DiscoverTargets(_ context.Context) ([]discovery_ki
 
 		extcommon.MergeAttributes(
 			attributes,
-			extcommon.GetPodBasedAttributes("deployment", deployment.ObjectMeta, d.k8s.PodsByLabelSelector(deployment.Spec.Selector, deployment.Namespace), nodes),
+			extcommon.GetPodBasedAttributes("deployment", deployment.ObjectMeta, d.k8s.PodsOwnedByDeployment(deployment.UID, deployment.Namespace), nodes),
 			extcommon.GetServiceNames(d.k8s.ServicesMatchingToPodLabels(deployment.Namespace, deployment.Spec.Template.Labels)),
 		)
 

--- a/extreplicaset/replicaset_discovery.go
+++ b/extreplicaset/replicaset_discovery.go
@@ -117,7 +117,7 @@ func (d *replicasetDiscovery) DiscoverTargets(_ context.Context) ([]discovery_ki
 
 		extcommon.MergeAttributes(
 			attributes,
-			extcommon.GetPodBasedAttributes("replicaset", replicaset.ObjectMeta, d.k8s.PodsByLabelSelector(replicaset.Spec.Selector, replicaset.Namespace), nodes),
+			extcommon.GetPodBasedAttributes("replicaset", replicaset.ObjectMeta, d.k8s.PodsByOwnerUid(replicaset.UID, replicaset.Namespace), nodes),
 			extcommon.GetServiceNames(d.k8s.ServicesMatchingToPodLabels(replicaset.Namespace, replicaset.Spec.Template.Labels)),
 		)
 

--- a/extreplicaset/replicaset_discovery_test.go
+++ b/extreplicaset/replicaset_discovery_test.go
@@ -208,6 +208,7 @@ func testReplicaSet(modifier func(*appsv1.ReplicaSet)) *appsv1.ReplicaSet {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "shop",
 			Namespace: "default",
+			UID:       "replicaset-shop-uid",
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					Kind: "Deployment",
@@ -305,6 +306,14 @@ func testPod(nameSuffix string, modifier func(*v1.Pod)) *v1.Pod {
 			Namespace: "default",
 			Labels: map[string]string{
 				"best-city": "kevelaer",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "ReplicaSet",
+					Name:       "shop",
+					UID:        "replicaset-shop-uid",
+				},
 			},
 		},
 		Status: v1.PodStatus{

--- a/extstatefulset/statefulset_discovery.go
+++ b/extstatefulset/statefulset_discovery.go
@@ -102,7 +102,7 @@ func (d *statefulSetDiscovery) DiscoverTargets(_ context.Context) ([]discovery_k
 		extcommon.AddNamespaceLabels(attributes, d.k8s, sts.Namespace)
 		extcommon.MergeAttributes(
 			attributes,
-			extcommon.GetPodBasedAttributes("statefulset", sts.ObjectMeta, d.k8s.PodsByLabelSelector(sts.Spec.Selector, sts.Namespace), nodes),
+			extcommon.GetPodBasedAttributes("statefulset", sts.ObjectMeta, d.k8s.PodsByOwnerUid(sts.UID, sts.Namespace), nodes),
 			extcommon.GetServiceNames(d.k8s.ServicesMatchingToPodLabels(sts.Namespace, sts.Spec.Template.Labels)),
 		)
 

--- a/extstatefulset/statefulset_discovery_test.go
+++ b/extstatefulset/statefulset_discovery_test.go
@@ -316,6 +316,14 @@ func testPod(nameSuffix string, modifier func(*v1.Pod)) *v1.Pod {
 			Labels: map[string]string{
 				"best-city": "kevelaer",
 			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "StatefulSet",
+					Name:       "shop",
+					UID:        "statefulset-shop-uid",
+				},
+			},
 		},
 		Status: v1.PodStatus{
 			Phase: v1.PodRunning,
@@ -346,6 +354,7 @@ func testStatefulSet(modifier func(set *appsv1.StatefulSet)) *appsv1.StatefulSet
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "shop",
 			Namespace: "default",
+			UID:       "statefulset-shop-uid",
 			Labels: map[string]string{
 				"best-city":    "Kevelaer",
 				"secret-label": "secret-value",


### PR DESCRIPTION
When the selectors of a statefulset are setup in a weird way, we copy data from unrelated pods to the stateful set.
Therefore we now copy by ownership instead of selectors.

re 13741