### PR TITLE
refa: align clusterName template to use dig-based nil-safe pattern

### DIFF
--- a/charts/steadybit-extension-kubernetes/Chart.yaml
+++ b/charts/steadybit-extension-kubernetes/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: steadybit-extension-kubernetes
 description: Steadybit Kubernetes extension Helm chart for Kubernetes.
-version: 1.6.9
+version: 1.6.10
 appVersion: v2.6.17
 home: https://www.steadybit.com/
 icon: https://steadybit-website-assets.s3.amazonaws.com/logo-symbol-transparent.png

--- a/charts/steadybit-extension-kubernetes/templates/deployment.yaml
+++ b/charts/steadybit-extension-kubernetes/templates/deployment.yaml
@@ -56,8 +56,10 @@ spec:
               cpu: {{ .Values.resources.limits.cpu }}
           env:
             {{- include "extensionlib.deployment.env" (list .) | nindent 12 }}
+            {{- with (.Values.kubernetes.clusterName | default (dig "clusterName" nil (.Values.global | default dict))) }}
             - name: STEADYBIT_EXTENSION_CLUSTER_NAME
-              value: {{ if and .Values.global .Values.global.clusterName }}{{ .Values.global.clusterName | quote }}{{ else }}{{ .Values.kubernetes.clusterName }}{{ end }}
+              value: {{ . | quote }}
+            {{- end }}
             {{- if .Values.kubernetes.namespaceFilter }}
             - name: STEADYBIT_EXTENSION_NAMESPACE
               value: {{ .Release.Namespace | quote }}

--- a/charts/steadybit-extension-kubernetes/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/steadybit-extension-kubernetes/tests/__snapshot__/deployment_test.yaml.snap
@@ -592,8 +592,6 @@ manifest should match snapshot with disabled excludes:
                   value: INFO
                 - name: STEADYBIT_LOG_FORMAT
                   value: text
-                - name: STEADYBIT_EXTENSION_CLUSTER_NAME
-                  value: null
                 - name: STEADYBIT_EXTENSION_DISABLE_DISCOVERY_EXCLUDES
                   value: "true"
                 - name: STEADYBIT_EXTENSION_DISCOVERY_DISABLED_CLUSTER
@@ -698,8 +696,6 @@ manifest should match snapshot with extra env vars:
                   value: INFO
                 - name: STEADYBIT_LOG_FORMAT
                   value: text
-                - name: STEADYBIT_EXTENSION_CLUSTER_NAME
-                  value: null
                 - name: STEADYBIT_EXTENSION_DISABLE_DISCOVERY_EXCLUDES
                   value: "false"
                 - name: STEADYBIT_EXTENSION_DISCOVERY_DISABLED_CLUSTER
@@ -813,8 +809,6 @@ manifest should match snapshot with extra labels:
                   value: INFO
                 - name: STEADYBIT_LOG_FORMAT
                   value: text
-                - name: STEADYBIT_EXTENSION_CLUSTER_NAME
-                  value: null
                 - name: STEADYBIT_EXTENSION_DISABLE_DISCOVERY_EXCLUDES
                   value: "false"
                 - name: STEADYBIT_EXTENSION_DISCOVERY_DISABLED_CLUSTER
@@ -1051,8 +1045,6 @@ manifest should match snapshot with mutual TLS using containerPaths:
                   value: /etc/tls/server.key
                 - name: STEADYBIT_EXTENSION_TLS_CLIENT_CAS
                   value: /etc/tls/ca.crt,/etc/tls/ca2.crt
-                - name: STEADYBIT_EXTENSION_CLUSTER_NAME
-                  value: null
                 - name: STEADYBIT_EXTENSION_DISABLE_DISCOVERY_EXCLUDES
                   value: "false"
                 - name: STEADYBIT_EXTENSION_DISCOVERY_DISABLED_CLUSTER
@@ -1157,8 +1149,6 @@ manifest should match snapshot with podSecurityContext:
                   value: INFO
                 - name: STEADYBIT_LOG_FORMAT
                   value: text
-                - name: STEADYBIT_EXTENSION_CLUSTER_NAME
-                  value: null
                 - name: STEADYBIT_EXTENSION_DISABLE_DISCOVERY_EXCLUDES
                   value: "false"
                 - name: STEADYBIT_EXTENSION_DISCOVERY_DISABLED_CLUSTER
@@ -1264,8 +1254,6 @@ manifest should match snapshot with priority class:
                   value: INFO
                 - name: STEADYBIT_LOG_FORMAT
                   value: text
-                - name: STEADYBIT_EXTENSION_CLUSTER_NAME
-                  value: null
                 - name: STEADYBIT_EXTENSION_DISABLE_DISCOVERY_EXCLUDES
                   value: "false"
                 - name: STEADYBIT_EXTENSION_DISCOVERY_DISABLED_CLUSTER


### PR DESCRIPTION
## Summary
- Replace verbose `if and .Values.global .Values.global.clusterName` pattern with `dig`-based nil-safe approach
- Consistent with the `global.priorityClassName` pattern
- Local `kubernetes.clusterName` takes precedence over `global.clusterName`