### PR TITLE
feat: support if-none-match for the extension list endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## (next)
+
+- Support if-none-match for the extension list endpoint
+
 
 ## v2.6.19
 

--- a/main.go
+++ b/main.go
@@ -54,6 +54,8 @@ import (
 	"github.com/steadybit/extension-kubernetes/v2/extstatefulset"
 )
 
+var startedAt = time.Now().Format(time.RFC3339)
+
 func main() {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
@@ -160,8 +162,6 @@ func main() {
 
 	discovery_kit_sdk.Register(extcommon.NewAttributeDescriber())
 
-	exthttp.RegisterHttpHandler("/", exthttp.GetterAsHandler(getExtensionList))
-
 	adviceCfg := extconfig.Config.AdviceConfig
 	advice_kit_sdk.RegisterAdvice(adviceCfg, deployment_strategy.GetAdviceDescriptionDeploymentStrategy)
 	advice_kit_sdk.RegisterAdvice(adviceCfg, cpu_limit.GetAdviceDescriptionCPULimit)
@@ -176,6 +176,8 @@ func main() {
 	advice_kit_sdk.RegisterAdvice(adviceCfg, single_replica.GetAdviceDescriptionSingleReplica)
 	advice_kit_sdk.RegisterAdvice(adviceCfg, host_podantiaffinity.GetAdviceDescriptionHostPodantiaffinity)
 	advice_kit_sdk.RegisterAdvice(adviceCfg, single_zone.GetAdviceDescriptionSingleZone)
+
+	exthttp.RegisterHttpHandler("/", exthttp.IfNoneMatchHandler(func() string { return startedAt }, exthttp.GetterAsHandler(getExtensionList)))
 
 	extsignals.ActivateSignalHandlers()
 	action_kit_sdk.RegisterCoverageEndpoints()


### PR DESCRIPTION
## Summary
- Wrap the `"/"` index handler with `exthttp.IfNoneMatchHandler` using a startup timestamp as ETag
- Allows clients to skip re-fetching the unchanged extension list via `If-None-Match` header
- Move index handler registration to after all action/discovery registrations for consistency

## Test plan
- [ ] Verify extension starts and responds to `GET /` with an `ETag` header
- [ ] Verify `GET /` with matching `If-None-Match` header returns `304 Not Modified`

🤖 Generated with [Claude Code](https://claude.com/claude-code)