### PR TITLE
feat: add non-graceful (SIGKILL) to Kubernetes crashloop attack

### DIFF
--- a/extpod/attack_cause_crashloop.go
+++ b/extpod/attack_cause_crashloop.go
@@ -161,7 +161,7 @@ func statusInternal(state *CrashLoopState) (*action_kit_api.StatusResult, error)
 		if err := runKubectlExec(state.Namespace, state.Pod, cs.Name, killCmd); err != nil {
 			log.Info().Err(err).Msgf("Failed to kill container %s in pod %s", cs.Name, state.Pod)
 
-			shellKillCmd := append([]string{"/bin/sh", "-c"}, killCmd...)
+			shellKillCmd := []string{"/bin/sh", "-c", strings.Join(killCmd, " ")}
 			if err := runKubectlExec(state.Namespace, state.Pod, cs.Name, shellKillCmd); err != nil {
 				return nil, fmt.Errorf("failed to kill container %s in pod %s: %w", cs.Name, state.Pod, err)
 			}

--- a/extpod/attack_cause_crashloop.go
+++ b/extpod/attack_cause_crashloop.go
@@ -123,6 +123,7 @@ func (f CrashLoopAction) Prepare(_ context.Context, state *CrashLoopState, reque
 	state.Namespace = namespace
 	state.Pod = podName
 	state.Container = config.Container
+	state.Graceful = config.Graceful
 	return nil, nil
 }
 
@@ -157,7 +158,7 @@ func statusInternal(state *CrashLoopState) (*action_kit_api.StatusResult, error)
 			continue
 		}
 
-		if err := runKubectlExec(state.Namespace, state.Pod, cs.Name, []string{"kill", "1"}); err != nil {
+		if err := runKubectlExec(state.Namespace, state.Pod, cs.Name, killCmd); err != nil {
 			log.Info().Err(err).Msgf("Failed to kill container %s in pod %s", cs.Name, state.Pod)
 
 			shellKillCmd := append([]string{"/bin/sh", "-c"}, killCmd...)

--- a/extpod/attack_cause_crashloop.go
+++ b/extpod/attack_cause_crashloop.go
@@ -25,10 +25,12 @@ type CrashLoopState struct {
 	Namespace string `json:"namespace"`
 	Pod       string `json:"pod"`
 	Container string `json:"container,omitempty"`
+	Graceful  bool   `json:"graceful"`
 }
 
 type CrashLoopConfig struct {
 	Container string `json:"container,omitempty"`
+	Graceful  bool   `json:"graceful"`
 }
 
 func NewCrashLoopAction() action_kit_sdk.Action[CrashLoopState] {
@@ -69,6 +71,16 @@ func (f CrashLoopAction) Describe() action_kit_api.ActionDescription {
 				Name:        "container",
 				Type:        action_kit_api.ActionParameterTypeString,
 				Advanced:    new(true),
+			},
+			{
+				Label:        "Graceful",
+				Description:  new("When true, sends SIGTERM (kill 1) to PID 1. When false, sends SIGKILL (kill -SIGKILL 1) for an immediate, non-recoverable kill."),
+				Advanced:     new(true),
+				Name:         "graceful",
+				Type:         action_kit_api.ActionParameterTypeBoolean,
+				DefaultValue: new("true"),
+				Order:        new(2),
+				Required:     new(true),
 			},
 		},
 		Prepare: action_kit_api.MutatingEndpointReference{},
@@ -129,6 +141,13 @@ func statusInternal(state *CrashLoopState) (*action_kit_api.StatusResult, error)
 		return nil, extension_kit.ToError(fmt.Sprintf("Pod %s not found in namespace %s", state.Pod, state.Namespace), nil)
 	}
 
+	var killCmd []string
+	if state.Graceful {
+		killCmd = []string{"kill", "1"}
+	} else {
+		killCmd = []string{"kill", "-SIGKILL", "1"}
+	}
+
 	for _, cs := range pod.Status.ContainerStatuses {
 		if state.Container != "" && state.Container != cs.Name {
 			continue
@@ -141,7 +160,8 @@ func statusInternal(state *CrashLoopState) (*action_kit_api.StatusResult, error)
 		if err := runKubectlExec(state.Namespace, state.Pod, cs.Name, []string{"kill", "1"}); err != nil {
 			log.Info().Err(err).Msgf("Failed to kill container %s in pod %s", cs.Name, state.Pod)
 
-			if err := runKubectlExec(state.Namespace, state.Pod, cs.Name, []string{"/bin/sh", "-c", "kill 1"}); err != nil {
+			shellKillCmd := append([]string{"/bin/sh", "-c"}, killCmd...)
+			if err := runKubectlExec(state.Namespace, state.Pod, cs.Name, shellKillCmd); err != nil {
 				return nil, fmt.Errorf("failed to kill container %s in pod %s: %w", cs.Name, state.Pod, err)
 			}
 		}

--- a/extpod/attack_cause_crashloop.go
+++ b/extpod/attack_cause_crashloop.go
@@ -92,7 +92,7 @@ func (f CrashLoopAction) Describe() action_kit_api.ActionDescription {
 }
 
 func (f CrashLoopAction) Prepare(_ context.Context, state *CrashLoopState, request action_kit_api.PrepareActionRequestBody) (*action_kit_api.PrepareResult, error) {
-	var config CrashLoopState
+	var config CrashLoopConfig
 	if err := extconversion.Convert(request.Config, &config); err != nil {
 		return nil, extension_kit.ToError("Failed to unmarshal the config.", err)
 	}

--- a/extpod/attack_cause_crashloop_test.go
+++ b/extpod/attack_cause_crashloop_test.go
@@ -21,6 +21,7 @@ func Test_Prepare(t *testing.T) {
 		podSpecContainerName string
 		podSpecHostPID       bool
 		configContainer      string
+		configGraceful       bool
 		wantState            CrashLoopState
 		wantErr              string
 	}{
@@ -41,10 +42,11 @@ func Test_Prepare(t *testing.T) {
 			name:                 "should return state for all container",
 			podSpecContainerName: "example",
 			podSpecHostPID:       false,
+			configGraceful:       true,
 			wantState: CrashLoopState{
 				Namespace: "shop",
 				Pod:       "checkout-xyz1234",
-				Graceful:  false,
+				Graceful:  true,
 			},
 		},
 		{
@@ -52,6 +54,7 @@ func Test_Prepare(t *testing.T) {
 			podSpecContainerName: "example",
 			podSpecHostPID:       false,
 			configContainer:      "example",
+			configGraceful:       false,
 			wantState: CrashLoopState{
 				Namespace: "shop",
 				Pod:       "checkout-xyz1234",
@@ -91,7 +94,7 @@ func Test_Prepare(t *testing.T) {
 			request := action_kit_api.PrepareActionRequestBody{
 				Config: map[string]any{
 					"container": tt.configContainer,
-					"graceful":  false,
+					"graceful":  tt.configGraceful,
 				},
 				Target: new(action_kit_api.Target{
 					Attributes: map[string][]string{
@@ -113,82 +116,6 @@ func Test_Prepare(t *testing.T) {
 			} else {
 				assert.EqualError(t, err, tt.wantErr)
 			}
-		})
-	}
-}
-
-func Test_Prepare_Graceful(t *testing.T) {
-	tests := []struct {
-		name      string
-		graceful  bool
-		wantState CrashLoopState
-	}{
-		{
-			name:     "graceful true stores true in state",
-			graceful: true,
-			wantState: CrashLoopState{
-				Namespace: "shop",
-				Pod:       "checkout-xyz1234",
-				Graceful:  true,
-			},
-		},
-		{
-			name:     "graceful false stores false in state",
-			graceful: false,
-			wantState: CrashLoopState{
-				Namespace: "shop",
-				Pod:       "checkout-xyz1234",
-				Graceful:  false,
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Given
-			stopCh := make(chan struct{})
-			defer close(stopCh)
-			testClient := getTestClient(stopCh, &corev1.Pod{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "Pod",
-					APIVersion: "v1",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "checkout-xyz1234",
-					Namespace: "shop",
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{Name: "example"},
-					},
-				},
-			})
-
-			assert.Eventually(t, func() bool {
-				return testClient.PodByNamespaceAndName("shop", "checkout-xyz1234") != nil
-			}, time.Second, 100*time.Millisecond)
-			client.K8S = testClient
-
-			request := action_kit_api.PrepareActionRequestBody{
-				Config: map[string]any{
-					"graceful": tt.graceful,
-				},
-				Target: new(action_kit_api.Target{
-					Attributes: map[string][]string{
-						"k8s.namespace": {"shop"},
-						"k8s.pod.name":  {"checkout-xyz1234"},
-					},
-				}),
-			}
-			action := NewCrashLoopAction()
-			state := action.NewEmptyState()
-
-			// When
-			_, err := action.Prepare(context.Background(), &state, request)
-
-			// Then
-			assert.NoError(t, err)
-			assert.Equal(t, tt.wantState, state)
 		})
 	}
 }

--- a/extpod/attack_cause_crashloop_test.go
+++ b/extpod/attack_cause_crashloop_test.go
@@ -44,6 +44,7 @@ func Test_Prepare(t *testing.T) {
 			wantState: CrashLoopState{
 				Namespace: "shop",
 				Pod:       "checkout-xyz1234",
+				Graceful:  false,
 			},
 		},
 		{
@@ -55,6 +56,7 @@ func Test_Prepare(t *testing.T) {
 				Namespace: "shop",
 				Pod:       "checkout-xyz1234",
 				Container: "example",
+				Graceful:  false,
 			},
 		},
 	}
@@ -89,6 +91,7 @@ func Test_Prepare(t *testing.T) {
 			request := action_kit_api.PrepareActionRequestBody{
 				Config: map[string]any{
 					"container": tt.configContainer,
+					"graceful":  false,
 				},
 				Target: new(action_kit_api.Target{
 					Attributes: map[string][]string{
@@ -110,6 +113,82 @@ func Test_Prepare(t *testing.T) {
 			} else {
 				assert.EqualError(t, err, tt.wantErr)
 			}
+		})
+	}
+}
+
+func Test_Prepare_Graceful(t *testing.T) {
+	tests := []struct {
+		name      string
+		graceful  bool
+		wantState CrashLoopState
+	}{
+		{
+			name:     "graceful true stores true in state",
+			graceful: true,
+			wantState: CrashLoopState{
+				Namespace: "shop",
+				Pod:       "checkout-xyz1234",
+				Graceful:  true,
+			},
+		},
+		{
+			name:     "graceful false stores false in state",
+			graceful: false,
+			wantState: CrashLoopState{
+				Namespace: "shop",
+				Pod:       "checkout-xyz1234",
+				Graceful:  false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Given
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+			testClient := getTestClient(stopCh, &corev1.Pod{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Pod",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "checkout-xyz1234",
+					Namespace: "shop",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "example"},
+					},
+				},
+			})
+
+			assert.Eventually(t, func() bool {
+				return testClient.PodByNamespaceAndName("shop", "checkout-xyz1234") != nil
+			}, time.Second, 100*time.Millisecond)
+			client.K8S = testClient
+
+			request := action_kit_api.PrepareActionRequestBody{
+				Config: map[string]any{
+					"graceful": tt.graceful,
+				},
+				Target: new(action_kit_api.Target{
+					Attributes: map[string][]string{
+						"k8s.namespace": {"shop"},
+						"k8s.pod.name":  {"checkout-xyz1234"},
+					},
+				}),
+			}
+			action := NewCrashLoopAction()
+			state := action.NewEmptyState()
+
+			// When
+			_, err := action.Prepare(context.Background(), &state, request)
+
+			// Then
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantState, state)
 		})
 	}
 }


### PR DESCRIPTION
This feature extends the existing crashloop attack to selectively send `kill -KILL` when a new parameter, `graceful`, is set to `false`.