### PR TITLE
fix: downgrade oasdiff/yaml to v0.0.9 to fix build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -70,8 +70,8 @@ require (
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/oapi-codegen/runtime v1.4.0 // indirect
-	github.com/oasdiff/yaml v0.1.0 // indirect
-	github.com/oasdiff/yaml3 v0.0.13 // indirect
+	github.com/oasdiff/yaml v0.0.9 // indirect
+	github.com/oasdiff/yaml3 v0.0.12 // indirect
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect


### PR DESCRIPTION
## Summary
- Commit `abef368` bumped `github.com/oasdiff/yaml` from `v0.0.9` to `v0.1.0` (and `yaml3` from `v0.0.12` to `v0.0.13`).
- `kin-openapi v0.138.0` (pulled in transitively via `action-kit/go/action_kit_api/v2`) still calls `yaml.UnmarshalWithOriginTree`, which was removed in `oasdiff/yaml v0.1.0`.
- This caused the Audit job to fail with `undefined: yaml.UnmarshalWithOriginTree` (see [run 25781432064](https://github.com/steadybit/extension-kubernetes/actions/runs/25781432064/job/75724816460)).
- Downgrading both modules restores the build until kin-openapi releases a version compatible with oasdiff/yaml v0.1.0.

## Test plan
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go mod verify`
- [ ] CI Audit job passes