### PR TITLE
docs: remove trivy-ignore bookkeeping from CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## v2.6.25
 
-- chore: add ignore to .trivyignore.yml
 - chore: update to go 1.26.4
 - feat: add weekly auto patch-release workflow
 - feat: roll up HPA + PDB attributes onto workload targets (#307)


### PR DESCRIPTION
Removes auto-generated trivy-ignore bookkeeping bullets from the most recent CHANGELOG entry. The auto patch-release workflow emitted these before the trivy-ignore filter landed in extension-kit; they don't represent user-visible changes.