### PR TITLE
build: rename workflow_dispatch input labels for the GH UI

### DIFF
--- a/.github/workflows/auto-patch-release.yml
+++ b/.github/workflows/auto-patch-release.yml
@@ -6,15 +6,15 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: If true, evaluate without committing or notifying Slack
+        description: Dry run (no commit, tag, or Slack notification)
         type: boolean
         default: true
       force_release:
-        description: If true, release even when the commit range contains unsafe commits
+        description: Force release (override unsafe-commit check)
         type: boolean
         default: false
       release_type:
-        description: Which component of the version to bump
+        description: Version bump
         type: choice
         options:
           - patch


### PR DESCRIPTION
GitHub renders workflow_dispatch input `description` as the field label in the UI. The original wording read as conditional sentence-fragments — these new label-style strings render cleanly:

- `dry_run`: `Dry run (no commit, tag, or Slack notification)`
- `force_release`: `Force release (override unsafe-commit check)`
- `release_type`: `Version bump`

Defaults and behavior unchanged.