### PR TITLE
feat: add status check mode and ready count = 0 to pod count check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v2.6.27
+
+- feat: add "Status Check Mode" (at least once / all the time) to the Deployment, StatefulSet, DaemonSet and ReplicaSet Pod Count Check. Defaults to "at least once" to keep the existing behavior (backward-compatible).
+- feat: add "ready count = 0" pod count check mode to validate that pods are scaled down.
+- The "Timeout" parameter of the Pod Count Check is now labeled "Duration" (label-only change, backward-compatible).
+
 ## v2.6.26
 
 - build(deps): bump alpine from 3.23 to 3.24

--- a/extcommon/pod_count_check.go
+++ b/extcommon/pod_count_check.go
@@ -19,11 +19,19 @@ import (
 
 const (
 	PodCountMin1                      CheckMode = "podCountMin1"
+	PodCountEquals0                   CheckMode = "podCountEquals0"
 	PodCountEqualsDesiredCount        CheckMode = "podCountEqualsDesiredCount"
 	PodCountGreaterEqualsDesiredCount CheckMode = "podCountGreaterEqualsDesiredCount"
 	PodCountLessThanDesiredCount      CheckMode = "podCountLessThanDesiredCount"
 	PodCountDecreased                 CheckMode = "podCountDecreased"
 	PodCountIncreased                 CheckMode = "podCountIncreased"
+)
+
+const (
+	// StatusCheckModeAtLeastOnce requires the condition to be fulfilled at least once within the duration.
+	StatusCheckModeAtLeastOnce StatusCheckMode = "atLeastOnce"
+	// StatusCheckModeAllTheTime requires the condition to be fulfilled during the complete duration.
+	StatusCheckModeAllTheTime StatusCheckMode = "allTheTime"
 )
 
 type PodCountCheckAction struct {
@@ -38,9 +46,12 @@ type PodCountCheckAction struct {
 
 type CheckMode string
 
+type StatusCheckMode string
+
 type PodCountCheckState struct {
 	Timeout           time.Time
 	PodCountCheckMode CheckMode
+	StatusCheckMode   StatusCheckMode
 	Namespace         string
 	Target            string
 	InitialCount      int
@@ -49,6 +60,7 @@ type PodCountCheckState struct {
 type PodCountCheckConfig struct {
 	Duration          int
 	PodCountCheckMode CheckMode
+	StatusCheckMode   StatusCheckMode
 }
 
 var _ action_kit_sdk.Action[PodCountCheckState] = (*PodCountCheckAction)(nil)
@@ -77,8 +89,8 @@ func (f PodCountCheckAction) Describe() action_kit_api.ActionDescription {
 		Parameters: []action_kit_api.ActionParameter{
 			{
 				Name:         "duration",
-				Label:        "Timeout",
-				Description:  new("How long should the check wait for the specified pod count."),
+				Label:        "Duration",
+				Description:  new("How long should the check run for the specified pod count."),
 				Type:         action_kit_api.ActionParameterTypeDuration,
 				DefaultValue: new("10s"),
 				Order:        new(1),
@@ -96,6 +108,10 @@ func (f PodCountCheckAction) Describe() action_kit_api.ActionDescription {
 					action_kit_api.ExplicitParameterOption{
 						Label: "ready count > 0",
 						Value: string(PodCountMin1),
+					},
+					action_kit_api.ExplicitParameterOption{
+						Label: "ready count = 0",
+						Value: string(PodCountEquals0),
 					},
 					action_kit_api.ExplicitParameterOption{
 						Label: "ready count = desired count",
@@ -116,6 +132,25 @@ func (f PodCountCheckAction) Describe() action_kit_api.ActionDescription {
 					action_kit_api.ExplicitParameterOption{
 						Label: "actual count decreases",
 						Value: string(PodCountDecreased),
+					},
+				}),
+			},
+			{
+				Name:         "statusCheckMode",
+				Label:        "Status Check Mode",
+				Description:  new("How often should the status be expected? At least once: the condition has to be fulfilled at least once within the given duration. All the time: the condition has to be fulfilled during the complete duration."),
+				Type:         action_kit_api.ActionParameterTypeString,
+				DefaultValue: new(string(StatusCheckModeAtLeastOnce)),
+				Order:        new(3),
+				Required:     new(true),
+				Options: new([]action_kit_api.ParameterOption{
+					action_kit_api.ExplicitParameterOption{
+						Label: "All the time",
+						Value: string(StatusCheckModeAllTheTime),
+					},
+					action_kit_api.ExplicitParameterOption{
+						Label: "At least once",
+						Value: string(StatusCheckModeAtLeastOnce),
 					},
 				}),
 			},
@@ -144,8 +179,14 @@ func (f PodCountCheckAction) Prepare(_ context.Context, state *PodCountCheckStat
 		return nil, extension_kit.ToError(fmt.Sprintf("%s/%s has no desired count", namespace, target), nil)
 	}
 
+	statusCheckMode := config.StatusCheckMode
+	if statusCheckMode == "" {
+		statusCheckMode = StatusCheckModeAtLeastOnce
+	}
+
 	state.Timeout = time.Now().Add(time.Millisecond * time.Duration(config.Duration))
 	state.PodCountCheckMode = config.PodCountCheckMode
+	state.StatusCheckMode = statusCheckMode
 	state.Namespace = namespace
 	state.Target = target
 	state.InitialCount = int(current)
@@ -165,7 +206,10 @@ func (f PodCountCheckAction) Status(_ context.Context, state *PodCountCheckState
 	}
 
 	readyCount := int(current)
-	desiredCount := int(*desired)
+	desiredCount := 0
+	if desired != nil {
+		desiredCount = int(*desired)
+	}
 
 	var checkError *action_kit_api.ActionKitError
 	switch state.PodCountCheckMode {
@@ -173,6 +217,13 @@ func (f PodCountCheckAction) Status(_ context.Context, state *PodCountCheckState
 		if !(readyCount >= 1) {
 			checkError = new(action_kit_api.ActionKitError{
 				Title:  fmt.Sprintf("%s/%s has no ready pods.", state.Namespace, state.Target),
+				Status: extutil.Ptr(action_kit_api.Failed),
+			})
+		}
+	case PodCountEquals0:
+		if !(readyCount == 0) {
+			checkError = new(action_kit_api.ActionKitError{
+				Title:  fmt.Sprintf("%s/%s has %d ready pods, expected 0.", state.Namespace, state.Target, readyCount),
 				Status: extutil.Ptr(action_kit_api.Failed),
 			})
 		}
@@ -218,15 +269,29 @@ func (f PodCountCheckAction) Status(_ context.Context, state *PodCountCheckState
 		})
 	}
 
+	if state.StatusCheckMode == StatusCheckModeAllTheTime {
+		// The condition must hold for the complete duration: fail fast on the first violation,
+		// otherwise keep checking until the duration has elapsed.
+		if checkError != nil {
+			return &action_kit_api.StatusResult{
+				Completed: true,
+				Error:     checkError,
+			}, nil
+		}
+		return &action_kit_api.StatusResult{
+			Completed: now.After(state.Timeout),
+		}, nil
+	}
+
+	// StatusCheckModeAtLeastOnce (default): succeed as soon as the condition is fulfilled,
+	// otherwise report the last error once the duration has elapsed.
 	if now.After(state.Timeout) {
 		return &action_kit_api.StatusResult{
 			Completed: true,
 			Error:     checkError,
 		}, nil
-	} else {
-		return &action_kit_api.StatusResult{
-			Completed: checkError == nil,
-		}, nil
 	}
-
+	return &action_kit_api.StatusResult{
+		Completed: checkError == nil,
+	}, nil
 }

--- a/extcommon/pod_count_check_test.go
+++ b/extcommon/pod_count_check_test.go
@@ -42,6 +42,22 @@ func Test_statusPodCountCheckInternal(t *testing.T) {
 			wantedErrorMessage: new("shop/checkout has no ready pods."),
 		},
 		{
+			name: "podCountEquals0Success",
+			preparedState: preparedState{
+				podCountCheckMode: PodCountEquals0,
+			},
+			readyCount:         0,
+			wantedErrorMessage: nil,
+		},
+		{
+			name: "podCountEquals0Failure",
+			preparedState: preparedState{
+				podCountCheckMode: PodCountEquals0,
+			},
+			readyCount:         2,
+			wantedErrorMessage: new("shop/checkout has 2 ready pods, expected 0."),
+		},
+		{
 			name: "podCountEqualsDesiredCountSuccess",
 			preparedState: preparedState{
 				podCountCheckMode: PodCountEqualsDesiredCount,
@@ -158,6 +174,115 @@ func Test_statusPodCountCheckInternal(t *testing.T) {
 				assert.Equalf(t, *tt.wantedErrorMessage, result.Error.Title, "Error message should be %s", *tt.wantedErrorMessage)
 			} else {
 				assert.Nil(t, result.Error, "Error should be nil")
+			}
+		})
+	}
+}
+
+func Test_statusPodCountCheckStatusCheckMode(t *testing.T) {
+	tests := []struct {
+		name            string
+		statusCheckMode StatusCheckMode
+		timeoutElapsed  bool
+		readyCount      int
+		desiredCount    int
+		wantCompleted   bool
+		wantError       bool
+	}{
+		{
+			name:            "atLeastOnce succeeds immediately when condition is met",
+			statusCheckMode: StatusCheckModeAtLeastOnce,
+			timeoutElapsed:  false,
+			readyCount:      2,
+			desiredCount:    2,
+			wantCompleted:   true,
+			wantError:       false,
+		},
+		{
+			name:            "atLeastOnce keeps running while condition is not met and timeout not reached",
+			statusCheckMode: StatusCheckModeAtLeastOnce,
+			timeoutElapsed:  false,
+			readyCount:      1,
+			desiredCount:    2,
+			wantCompleted:   false,
+			wantError:       false,
+		},
+		{
+			name:            "atLeastOnce fails once timeout reached and condition never met",
+			statusCheckMode: StatusCheckModeAtLeastOnce,
+			timeoutElapsed:  true,
+			readyCount:      1,
+			desiredCount:    2,
+			wantCompleted:   true,
+			wantError:       true,
+		},
+		{
+			name:            "empty status check mode defaults to atLeastOnce",
+			statusCheckMode: "",
+			timeoutElapsed:  false,
+			readyCount:      2,
+			desiredCount:    2,
+			wantCompleted:   true,
+			wantError:       false,
+		},
+		{
+			name:            "allTheTime keeps running while condition holds and timeout not reached",
+			statusCheckMode: StatusCheckModeAllTheTime,
+			timeoutElapsed:  false,
+			readyCount:      2,
+			desiredCount:    2,
+			wantCompleted:   false,
+			wantError:       false,
+		},
+		{
+			name:            "allTheTime fails fast when condition is violated",
+			statusCheckMode: StatusCheckModeAllTheTime,
+			timeoutElapsed:  false,
+			readyCount:      1,
+			desiredCount:    2,
+			wantCompleted:   true,
+			wantError:       true,
+		},
+		{
+			name:            "allTheTime succeeds once the duration has elapsed without violation",
+			statusCheckMode: StatusCheckModeAllTheTime,
+			timeoutElapsed:  true,
+			readyCount:      2,
+			desiredCount:    2,
+			wantCompleted:   true,
+			wantError:       false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			timeout := time.Now().Add(time.Minute)
+			if tt.timeoutElapsed {
+				timeout = time.Now().Add(-time.Minute)
+			}
+
+			state := PodCountCheckState{
+				Timeout:           timeout,
+				PodCountCheckMode: PodCountEqualsDesiredCount,
+				StatusCheckMode:   tt.statusCheckMode,
+				Namespace:         "shop",
+				Target:            "checkout",
+			}
+
+			action := &PodCountCheckAction{
+				ActionId:   "test",
+				TargetType: "testTargetType",
+				GetDesiredAndCurrentPodCount: func(k8s *client.Client, namespace string, target string) (*int32, int32, error) {
+					return new(int32(tt.desiredCount)), int32(tt.readyCount), nil
+				},
+			}
+
+			result, err := action.Status(context.Background(), &state)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantCompleted, result.Completed)
+			if tt.wantError {
+				assert.NotNil(t, result.Error)
+			} else {
+				assert.Nil(t, result.Error)
 			}
 		})
 	}

--- a/extdeployment/deployment_pod_count_check_test.go
+++ b/extdeployment/deployment_pod_count_check_test.go
@@ -72,6 +72,7 @@ func TestPrepareCheckExtractsState(t *testing.T) {
 	require.Nil(t, result)
 	require.True(t, state.Timeout.After(time.Now()))
 	require.Equal(t, extcommon.PodCountEqualsDesiredCount, state.PodCountCheckMode)
+	require.Equal(t, extcommon.StatusCheckModeAtLeastOnce, state.StatusCheckMode, "missing statusCheckMode must default to atLeastOnce for backward compatibility")
 	require.Equal(t, "shop", state.Namespace)
 	require.Equal(t, "checkout", state.Target)
 	require.Equal(t, 3, state.InitialCount)


### PR DESCRIPTION
## Why

While building a Kubernetes liveness/readiness template, we hit a gap: the Pod Count Check can only express *"deployment X reaches the expected pod count **within** duration X"* (a timeout). It cannot express:

- *"deployment X stays **healthy** for duration X"*
- *"deployment X stays **unhealthy** for duration X"*

This matters for service validation: a "5 min service validation" today passes if the condition is true for a single second. It also could not assert that pods are fully **scaled down** (count = 0).

## What

The Deployment / StatefulSet / DaemonSet / ReplicaSet **Pod Count Check** now supports:

1. **Status Check Mode** (like the Datadog Monitor check):
   - **At least once** *(default)* — condition must be met at least once within the duration. Identical to today's behavior → **backward compatible**.
   - **All the time** — condition must hold for the **complete** duration, failing fast on the first violation. Expresses "(un)healthy for a given duration".
2. **`ready count = 0`** pod count mode — validate that pods are scaled down.
3. **`Timeout` → `Duration`** — label-only rename. The underlying parameter name stays `duration`, so existing experiments keep working.

## Non-breaking change

The old Pod Count Check finished the moment its condition was fulfilled. That behavior is preserved exactly:

- **Default is `atLeastOnce`** — set in `Describe` and defaulted in `Prepare` when the field is empty, so old experiments that never send `statusCheckMode` get it too.
- The `atLeastOnce` branch in `Status` is the original logic, unchanged (just moved below the new `allTheTime` branch):

```go
// StatusCheckModeAtLeastOnce (default): succeed as soon as the condition is fulfilled,
// otherwise report the last error once the duration has elapsed.
if now.After(state.Timeout) {
    return &action_kit_api.StatusResult{Completed: true, Error: checkError}, nil
}
return &action_kit_api.StatusResult{Completed: checkError == nil}, nil
```

When the condition is met before the duration elapses, `checkError == nil` → `Completed: true` on that very poll, so the check **finishes immediately** — byte-for-byte the same as before.

Flow per mode:

| Situation | at least once (default) | all the time |
|---|---|---|
| Condition met, duration not elapsed | **finishes now, success** ✅ (old behavior) | keeps running |
| Condition not met, duration not elapsed | keeps running | **finishes now, fail** |
| Duration elapsed | finishes with last result | finishes, success (no violation seen) |

Other guarantees:
- Parameter name `duration` is unchanged; only its label changed (`Timeout` → `Duration`).
- The desired-count dereference is now nil-guarded so count-only modes can't panic.

## Tests

- New table cases for `podCountEquals0` (success/failure).
- New `Test_statusPodCountCheckStatusCheckMode` covering at-least-once vs. all-the-time before/after the duration elapses, plus the empty-mode default. The *"atLeastOnce succeeds immediately when condition is met"* case asserts `Completed == true` with the timeout still in the future, proving the check ends early rather than waiting out the duration.
- `TestPrepareCheckExtractsState` asserts a missing `statusCheckMode` defaults to `atLeastOnce`.
- `go test ./extcommon/... ./extdeployment/... ./extstatefulset/... ./extdaemonset/... ./extreplicaset/...` → all green.

## Follow-ups / notes

- Hub documentation (hub.steadybit.com) is driven by these action descriptions; the new option labels/descriptions are included here. Any standalone Hub docs should be refreshed to mention the new mode.
- Ending the check early once the condition is met (at-least-once) is unchanged and tracked separately in [KBZ-11259](https://steadybitgmbh.kanbanize.com/ctrl_board/9/cards/11259/details/).