### PR TITLE
feat: expose liveness/readiness HTTP probe paths as discovery attributes

### DIFF
--- a/extcommon/attributes.go
+++ b/extcommon/attributes.go
@@ -82,6 +82,20 @@ func (a *attributeDescriber) DescribeAttributes() []discovery_kit_api.AttributeD
 				Other: "ReplicaSet names",
 			},
 		},
+		{
+			Attribute: LivenessProbePathAttribute,
+			Label: discovery_kit_api.PluralLabel{
+				One:   "Liveness probe path",
+				Other: "Liveness probe paths",
+			},
+		},
+		{
+			Attribute: ReadinessProbePathAttribute,
+			Label: discovery_kit_api.PluralLabel{
+				One:   "Readiness probe path",
+				Other: "Readiness probe paths",
+			},
+		},
 	}
 }
 

--- a/extcommon/probes.go
+++ b/extcommon/probes.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025 Steadybit GmbH
+
+package extcommon
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	LivenessProbePathAttribute  = "k8s.specification.probes.liveness.path"
+	ReadinessProbePathAttribute = "k8s.specification.probes.readiness.path"
+)
+
+// AddProbePathAttributes extracts the HTTP path of the liveness and readiness
+// probes from the given containers and adds them as discovery attributes. Only
+// HTTP probes (httpGet) expose a path; tcp/exec/grpc probes are ignored.
+func AddProbePathAttributes(attributes map[string][]string, containers []corev1.Container) {
+	probePaths := map[string][]string{}
+	for i := range containers {
+		if path := httpProbePath(containers[i].LivenessProbe); path != "" {
+			probePaths[LivenessProbePathAttribute] = append(probePaths[LivenessProbePathAttribute], path)
+		}
+		if path := httpProbePath(containers[i].ReadinessProbe); path != "" {
+			probePaths[ReadinessProbePathAttribute] = append(probePaths[ReadinessProbePathAttribute], path)
+		}
+	}
+	MergeAttributes(attributes, probePaths)
+}
+
+// httpProbePath returns the HTTP path of an httpGet probe. An httpGet probe with
+// an empty path targets the root "/", so that is reported. Non-HTTP probes
+// return an empty string.
+func httpProbePath(probe *corev1.Probe) string {
+	if probe == nil || probe.HTTPGet == nil {
+		return ""
+	}
+	if probe.HTTPGet.Path == "" {
+		return "/"
+	}
+	return probe.HTTPGet.Path
+}

--- a/extcommon/probes_test.go
+++ b/extcommon/probes_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025 Steadybit GmbH
+
+package extcommon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func httpProbe(path string) *corev1.Probe {
+	return &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path: path,
+				Port: intstr.FromInt32(8080),
+			},
+		},
+	}
+}
+
+func tcpProbe() *corev1.Probe {
+	return &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			TCPSocket: &corev1.TCPSocketAction{Port: intstr.FromInt32(8080)},
+		},
+	}
+}
+
+func TestAddProbePathAttributes(t *testing.T) {
+	tests := []struct {
+		name       string
+		containers []corev1.Container
+		expected   map[string][]string
+	}{
+		{
+			name: "liveness and readiness http probes",
+			containers: []corev1.Container{
+				{LivenessProbe: httpProbe("/healthz"), ReadinessProbe: httpProbe("/ready")},
+			},
+			expected: map[string][]string{
+				LivenessProbePathAttribute:  {"/healthz"},
+				ReadinessProbePathAttribute: {"/ready"},
+			},
+		},
+		{
+			name: "empty path defaults to root",
+			containers: []corev1.Container{
+				{LivenessProbe: httpProbe("")},
+			},
+			expected: map[string][]string{
+				LivenessProbePathAttribute: {"/"},
+			},
+		},
+		{
+			name: "non-http probes are ignored",
+			containers: []corev1.Container{
+				{LivenessProbe: tcpProbe(), ReadinessProbe: nil},
+			},
+			expected: map[string][]string{},
+		},
+		{
+			name: "multiple containers are deduplicated and sorted",
+			containers: []corev1.Container{
+				{LivenessProbe: httpProbe("/healthz")},
+				{LivenessProbe: httpProbe("/alive")},
+				{LivenessProbe: httpProbe("/healthz")},
+			},
+			expected: map[string][]string{
+				LivenessProbePathAttribute: {"/alive", "/healthz"},
+			},
+		},
+		{
+			name:       "no containers",
+			containers: nil,
+			expected:   map[string][]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attributes := map[string][]string{}
+			AddProbePathAttributes(attributes, tt.containers)
+			assert.Equal(t, tt.expected, attributes)
+		})
+	}
+}

--- a/extdaemonset/daemonset_discovery.go
+++ b/extdaemonset/daemonset_discovery.go
@@ -116,6 +116,8 @@ func (d *daemonSetDiscovery) DiscoverTargets(_ context.Context) ([]discovery_kit
 			extcommon.AddPdbAttributes(attributes, d.k8s.PodDisruptionBudgetsForPodLabels(ds.Namespace, ds.Spec.Template.Labels))
 		}
 
+		extcommon.AddProbePathAttributes(attributes, ds.Spec.Template.Spec.Containers)
+
 		targets[i] = discovery_kit_api.Target{
 			Id:         fmt.Sprintf("%s/%s/%s", extconfig.Config.ClusterName, ds.Namespace, ds.Name),
 			TargetType: DaemonSetTargetType,

--- a/extdeployment/deployment_discovery.go
+++ b/extdeployment/deployment_discovery.go
@@ -134,6 +134,7 @@ func (d *deploymentDiscovery) DiscoverTargets(_ context.Context) ([]discovery_ki
 		for container := range deployment.Spec.Template.Spec.Containers {
 			attributes["k8s.container.name"] = append(attributes["k8s.container.name"], deployment.Spec.Template.Spec.Containers[container].Name)
 		}
+		extcommon.AddProbePathAttributes(attributes, deployment.Spec.Template.Spec.Containers)
 
 		targets[i] = discovery_kit_api.Target{
 			Id:         fmt.Sprintf("%s/%s/%s", extconfig.Config.ClusterName, deployment.Namespace, deployment.Name),

--- a/extdeployment/deployment_discovery_test.go
+++ b/extdeployment/deployment_discovery_test.go
@@ -164,7 +164,9 @@ func Test_deploymentDiscovery(t *testing.T) {
 			}),
 			service: testService(nil),
 			expectedAttributes: map[string][]string{
-				"k8s.specification.probes.summary": {"OK"},
+				"k8s.specification.probes.summary":        {"OK"},
+				"k8s.specification.probes.liveness.path":  {"/live"},
+				"k8s.specification.probes.readiness.path": {"/ready"},
 			},
 		},
 		{

--- a/extstatefulset/statefulset_discovery.go
+++ b/extstatefulset/statefulset_discovery.go
@@ -123,6 +123,8 @@ func (d *statefulSetDiscovery) DiscoverTargets(_ context.Context) ([]discovery_k
 			extcommon.AddPdbAttributes(attributes, d.k8s.PodDisruptionBudgetsForPodLabels(sts.Namespace, sts.Spec.Template.Labels))
 		}
 
+		extcommon.AddProbePathAttributes(attributes, sts.Spec.Template.Spec.Containers)
+
 		targets[i] = discovery_kit_api.Target{
 			Id:         fmt.Sprintf("%s/%s/%s", extconfig.Config.ClusterName, sts.Namespace, sts.Name),
 			TargetType: StatefulSetTargetType,


### PR DESCRIPTION
## What

Adds two discovery attributes for `deployment`, `daemonset` and `statefulset` targets:

- `k8s.specification.probes.liveness.path`
- `k8s.specification.probes.readiness.path`

## Why

The AI agent frequently has to ask the user for the path when assembling an HTTP check. The liveness/readiness probe paths are already declared on the workload spec, so we expose them as discovery attributes the agent can reuse directly.

## Notes

- Only `httpGet` probes expose a path; `tcp`/`exec`/`grpc` probes are ignored.
- An `httpGet` probe with an empty path targets the root, so `/` is reported.
- The probe **port** is intentionally omitted: it is a *container* port that rarely matches the *service* port an agent actually targets. The path is the part that stays correct once the agent resolves the service host/port.
- Multiple containers are merged, deduplicated and sorted.

## Tests

- Unit test for the extraction helper (`extcommon/probes_test.go`).
- Extended the deployment discovery test to assert the attributes end-to-end.