### PR TITLE
feat: emit readiness widget metrics from Deployment and StatefulSet pod count checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,11 @@
 # Changelog
 
-## v2.6.28
-
-- feat: Deployment and StatefulSet Pod Count Checks now emit pod-count metrics and show the readiness widget alongside the check timeline.
-- refactor: extract shared `BuildPodCountMetrics` helper in `extcommon` so the Pod Count Metrics action and the Pod Count Checks use one code path for metric construction.
-
 ## v2.6.27
 
 - feat: add "Status Check Mode" (at least once / all the time) to the Deployment, StatefulSet, DaemonSet and ReplicaSet Pod Count Check. Defaults to "at least once" to keep the existing behavior (backward-compatible).
 - feat: add "ready count = 0" pod count check mode to validate that pods are scaled down.
 - The "Timeout" parameter of the Pod Count Check is now labeled "Duration" (label-only change, backward-compatible).
+- feat: Deployment and StatefulSet Pod Count Checks now emit pod-count metrics and show the readiness widget alongside the check timeline.
 
 ## v2.6.26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.6.28
+
+- feat: Deployment and StatefulSet Pod Count Checks now emit pod-count metrics and show the readiness widget alongside the check timeline.
+- refactor: extract shared `BuildPodCountMetrics` helper in `extcommon` so the Pod Count Metrics action and the Pod Count Checks use one code path for metric construction.
+
 ## v2.6.27
 
 - feat: add "Status Check Mode" (at least once / all the time) to the Deployment, StatefulSet, DaemonSet and ReplicaSet Pod Count Check. Defaults to "at least once" to keep the existing behavior (backward-compatible).

--- a/extcommon/pod_count_check.go
+++ b/extcommon/pod_count_check.go
@@ -42,6 +42,17 @@ type PodCountCheckAction struct {
 	SelectionTemplates           *action_kit_api.TargetSelectionTemplates
 	GetTarget                    func(request action_kit_api.PrepareActionRequestBody) string
 	GetDesiredAndCurrentPodCount func(k8s *client.Client, namespace string, target string) (*int32, int32, error)
+	// GetPodCountMetrics is optional. When set, Status() emits pod-count metric
+	// series each tick so the widget can render alongside the check.
+	GetPodCountMetrics func(k8s *client.Client, namespace string, target string) (*PodCountMetrics, error)
+	// MetricLabelKey is the k8s label key used to identify the resource in emitted
+	// metrics (e.g. "k8s.deployment" or "k8s.statefulset"). Required when
+	// GetPodCountMetrics is set.
+	MetricLabelKey string
+	// Widget is optional. When set it is included in Describe() so the platform
+	// renders it next to the check timeline. Pass an action_kit_api.PredefinedWidget
+	// or any other concrete widget type.
+	Widget interface{}
 }
 
 type CheckMode string
@@ -54,6 +65,7 @@ type PodCountCheckState struct {
 	StatusCheckMode   StatusCheckMode
 	Namespace         string
 	Target            string
+	MetricLabelKey    string
 	InitialCount      int
 }
 
@@ -155,6 +167,12 @@ func (f PodCountCheckAction) Describe() action_kit_api.ActionDescription {
 				}),
 			},
 		},
+		Widgets: func() *[]action_kit_api.Widget {
+			if f.Widget == nil {
+				return nil
+			}
+			return &[]action_kit_api.Widget{f.Widget}
+		}(),
 		Prepare: action_kit_api.MutatingEndpointReference{},
 		Start:   action_kit_api.MutatingEndpointReference{},
 		Status: new(action_kit_api.MutatingEndpointReferenceWithCallInterval{
@@ -189,6 +207,7 @@ func (f PodCountCheckAction) Prepare(_ context.Context, state *PodCountCheckStat
 	state.StatusCheckMode = statusCheckMode
 	state.Namespace = namespace
 	state.Target = target
+	state.MetricLabelKey = f.MetricLabelKey
 	state.InitialCount = int(current)
 	return nil, nil
 }
@@ -209,6 +228,14 @@ func (f PodCountCheckAction) Status(_ context.Context, state *PodCountCheckState
 	desiredCount := 0
 	if desired != nil {
 		desiredCount = int(*desired)
+	}
+
+	var metrics []action_kit_api.Metric
+	if f.GetPodCountMetrics != nil {
+		counts, metricsErr := f.GetPodCountMetrics(f.Client, state.Namespace, state.Target)
+		if metricsErr == nil && counts != nil {
+			metrics = BuildPodCountMetrics(state.MetricLabelKey, state.Namespace, state.Target, *counts, now)
+		}
 	}
 
 	var checkError *action_kit_api.ActionKitError
@@ -269,6 +296,13 @@ func (f PodCountCheckAction) Status(_ context.Context, state *PodCountCheckState
 		})
 	}
 
+	metricsPtr := func() *[]action_kit_api.Metric {
+		if len(metrics) == 0 {
+			return nil
+		}
+		return &metrics
+	}()
+
 	if state.StatusCheckMode == StatusCheckModeAllTheTime {
 		// The condition must hold for the complete duration: fail fast on the first violation,
 		// otherwise keep checking until the duration has elapsed.
@@ -276,10 +310,12 @@ func (f PodCountCheckAction) Status(_ context.Context, state *PodCountCheckState
 			return &action_kit_api.StatusResult{
 				Completed: true,
 				Error:     checkError,
+				Metrics:   metricsPtr,
 			}, nil
 		}
 		return &action_kit_api.StatusResult{
 			Completed: now.After(state.Timeout),
+			Metrics:   metricsPtr,
 		}, nil
 	}
 
@@ -289,9 +325,11 @@ func (f PodCountCheckAction) Status(_ context.Context, state *PodCountCheckState
 		return &action_kit_api.StatusResult{
 			Completed: true,
 			Error:     checkError,
+			Metrics:   metricsPtr,
 		}, nil
 	}
 	return &action_kit_api.StatusResult{
 		Completed: checkError == nil,
+		Metrics:   metricsPtr,
 	}, nil
 }

--- a/extcommon/pod_count_metrics.go
+++ b/extcommon/pod_count_metrics.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025 Steadybit GmbH
+
+package extcommon
+
+import (
+	"time"
+
+	"github.com/steadybit/action-kit/go/action_kit_api/v2"
+	"github.com/steadybit/extension-kubernetes/v2/extconfig"
+)
+
+// PodCountMetrics holds the four replica counts needed to build pod-count metric series.
+type PodCountMetrics struct {
+	Desired   int32
+	Current   int32
+	Ready     int32
+	Available int32
+}
+
+// BuildPodCountMetrics produces the four replicas_* metrics consumed by the
+// DeploymentReadinessWidget. labelKey is the resource-type label
+// (e.g. "k8s.deployment" or "k8s.statefulset").
+func BuildPodCountMetrics(labelKey, namespace, name string, counts PodCountMetrics, now time.Time) []action_kit_api.Metric {
+	labels := map[string]string{
+		"k8s.cluster-name": extconfig.Config.ClusterName,
+		"k8s.namespace":    namespace,
+		labelKey:           name,
+	}
+	return []action_kit_api.Metric{
+		{Name: new("replicas_desired_count"), Metric: labels, Timestamp: now, Value: float64(counts.Desired)},
+		{Name: new("replicas_current_count"), Metric: labels, Timestamp: now, Value: float64(counts.Current)},
+		{Name: new("replicas_ready_count"), Metric: labels, Timestamp: now, Value: float64(counts.Ready)},
+		{Name: new("replicas_available_count"), Metric: labels, Timestamp: now, Value: float64(counts.Available)},
+	}
+}

--- a/extdeployment/deployment_pod_count_check.go
+++ b/extdeployment/deployment_pod_count_check.go
@@ -11,6 +11,7 @@ import (
 	extension_kit "github.com/steadybit/extension-kit"
 	"github.com/steadybit/extension-kubernetes/v2/client"
 	"github.com/steadybit/extension-kubernetes/v2/extcommon"
+	appsv1 "k8s.io/api/apps/v1"
 )
 
 func NewDeploymentPodCountCheckAction(k8s *client.Client) action_kit_sdk.Action[extcommon.PodCountCheckState] {
@@ -36,5 +37,30 @@ func NewDeploymentPodCountCheckAction(k8s *client.Client) action_kit_sdk.Action[
 			}
 			return d.Spec.Replicas, d.Status.ReadyReplicas, nil
 		},
+		MetricLabelKey: "k8s.deployment",
+		GetPodCountMetrics: func(k8s *client.Client, namespace string, target string) (*extcommon.PodCountMetrics, error) {
+			d := k8s.DeploymentByNamespaceAndName(namespace, target)
+			if d == nil {
+				return nil, nil
+			}
+			return deploymentPodCountMetrics(d), nil
+		},
+		Widget: action_kit_api.PredefinedWidget{
+			Type:               action_kit_api.ComSteadybitWidgetPredefined,
+			PredefinedWidgetId: "com.steadybit.widget.predefined.DeploymentReadinessWidget",
+		},
+	}
+}
+
+func deploymentPodCountMetrics(d *appsv1.Deployment) *extcommon.PodCountMetrics {
+	var desired int32
+	if d.Spec.Replicas != nil {
+		desired = *d.Spec.Replicas
+	}
+	return &extcommon.PodCountMetrics{
+		Desired:   desired,
+		Current:   d.Status.Replicas,
+		Ready:     d.Status.ReadyReplicas,
+		Available: d.Status.AvailableReplicas,
 	}
 }

--- a/extdeployment/pod_count_metrics.go
+++ b/extdeployment/pod_count_metrics.go
@@ -16,7 +16,7 @@ import (
 	"github.com/steadybit/extension-kit/extutil"
 	"github.com/steadybit/extension-kubernetes/v2/client"
 	"github.com/steadybit/extension-kubernetes/v2/extcluster"
-	"github.com/steadybit/extension-kubernetes/v2/extconfig"
+	"github.com/steadybit/extension-kubernetes/v2/extcommon"
 	appsv1 "k8s.io/api/apps/v1"
 )
 
@@ -150,48 +150,5 @@ func getMetricKey(deployment *appsv1.Deployment, metric string) string {
 }
 
 func toMetrics(deployment *appsv1.Deployment, now time.Time) []action_kit_api.Metric {
-	metrics := make([]action_kit_api.Metric, 4)
-
-	metrics[0] = action_kit_api.Metric{
-		Name: new("replicas_desired_count"),
-		Metric: map[string]string{
-			"k8s.cluster-name": extconfig.Config.ClusterName,
-			"k8s.namespace":    deployment.Namespace,
-			"k8s.deployment":   deployment.Name,
-		},
-		Timestamp: now,
-		Value:     float64(*deployment.Spec.Replicas),
-	}
-	metrics[1] = action_kit_api.Metric{
-		Name: new("replicas_current_count"),
-		Metric: map[string]string{
-			"k8s.cluster-name": extconfig.Config.ClusterName,
-			"k8s.namespace":    deployment.Namespace,
-			"k8s.deployment":   deployment.Name,
-		},
-		Timestamp: now,
-		Value:     float64(deployment.Status.Replicas),
-	}
-	metrics[2] = action_kit_api.Metric{
-		Name: new("replicas_ready_count"),
-		Metric: map[string]string{
-			"k8s.cluster-name": extconfig.Config.ClusterName,
-			"k8s.namespace":    deployment.Namespace,
-			"k8s.deployment":   deployment.Name,
-		},
-		Timestamp: now,
-		Value:     float64(deployment.Status.ReadyReplicas),
-	}
-	metrics[3] = action_kit_api.Metric{
-		Name: new("replicas_available_count"),
-		Metric: map[string]string{
-			"k8s.cluster-name": extconfig.Config.ClusterName,
-			"k8s.namespace":    deployment.Namespace,
-			"k8s.deployment":   deployment.Name,
-		},
-		Timestamp: now,
-		Value:     float64(deployment.Status.AvailableReplicas),
-	}
-
-	return metrics
+	return extcommon.BuildPodCountMetrics("k8s.deployment", deployment.Namespace, deployment.Name, *deploymentPodCountMetrics(deployment), now)
 }

--- a/extstatefulset/statefulset_pod_count_check.go
+++ b/extstatefulset/statefulset_pod_count_check.go
@@ -11,6 +11,7 @@ import (
 	extension_kit "github.com/steadybit/extension-kit"
 	"github.com/steadybit/extension-kubernetes/v2/client"
 	"github.com/steadybit/extension-kubernetes/v2/extcommon"
+	appsv1 "k8s.io/api/apps/v1"
 )
 
 func NewStatefulSetPodCountCheckAction(k8s *client.Client) action_kit_sdk.Action[extcommon.PodCountCheckState] {
@@ -36,5 +37,30 @@ func NewStatefulSetPodCountCheckAction(k8s *client.Client) action_kit_sdk.Action
 			}
 			return d.Spec.Replicas, d.Status.ReadyReplicas, nil
 		},
+		MetricLabelKey: "k8s.statefulset",
+		GetPodCountMetrics: func(k8s *client.Client, namespace string, target string) (*extcommon.PodCountMetrics, error) {
+			d := k8s.StatefulSetByNamespaceAndName(namespace, target)
+			if d == nil {
+				return nil, nil
+			}
+			return statefulSetPodCountMetrics(d), nil
+		},
+		Widget: action_kit_api.PredefinedWidget{
+			Type:               action_kit_api.ComSteadybitWidgetPredefined,
+			PredefinedWidgetId: "com.steadybit.widget.predefined.DeploymentReadinessWidget",
+		},
+	}
+}
+
+func statefulSetPodCountMetrics(d *appsv1.StatefulSet) *extcommon.PodCountMetrics {
+	var desired int32
+	if d.Spec.Replicas != nil {
+		desired = *d.Spec.Replicas
+	}
+	return &extcommon.PodCountMetrics{
+		Desired:   desired,
+		Current:   d.Status.Replicas,
+		Ready:     d.Status.ReadyReplicas,
+		Available: d.Status.AvailableReplicas,
 	}
 }


### PR DESCRIPTION
## Why

The Pod Count Metrics action already shows a readiness chart for Deployments in the experiment run view — but only when you explicitly add it as a separate step. The Pod Count Check, which users already add to validate deployment health, had no equivalent visualisation.

## What

The **Deployment** and **StatefulSet Pod Count Checks** now:

1. Emit the four `replicas_*` metric series (`desired`, `current`, `ready`, `available`) on every status tick.
2. Declare the `DeploymentReadinessWidget` in their `Describe()` so the platform renders the chart inline alongside the check timeline — no extra step needed.

DaemonSet and ReplicaSet are intentionally excluded; the readiness widget is not meaningful for those resource types.

## Refactoring

The four-metric construction was previously duplicated in `extdeployment/pod_count_metrics.go`. This PR extracts a shared `BuildPodCountMetrics(labelKey, namespace, name string, counts PodCountMetrics, now time.Time)` helper in `extcommon`, parameterised by resource label key (`k8s.deployment`, `k8s.statefulset`, …). The existing Pod Count Metrics action and the two checks all call the same path.

## Architecture

```
extcommon.BuildPodCountMetrics()          ← single source of truth for metric construction
    ↑                      ↑
extdeployment/             extstatefulset/
  pod_count_metrics.go       statefulset_pod_count_check.go
  deployment_pod_count_check.go
```

The `PodCountCheckAction` struct gains two optional fields:
- `GetPodCountMetrics` — callback returning the 4 counts for the target; when nil, no metrics are emitted (DaemonSet/ReplicaSet keep existing behaviour).
- `MetricLabelKey` — the k8s label key written into the metric labels.
- `Widget` — an `interface{}` widget passed through to `Describe()`; when nil, no widget is declared.

All three default to nil/empty, so the change is fully backward-compatible.

## Tests

- `go test ./extcommon/... ./extdeployment/... ./extstatefulset/...` → all green.