### PR TITLE
fix: sort multi-value discovery attributes to prevent spurious change detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: sort multi-value discovery attributes (`k8s.container.id`, `k8s.pod.name`, `k8s.namespace`, `k8s.replicaset`, `k8s.deployment`, `k8s.daemonset`, `k8s.statefulset`, `k8s.service.name`) before attaching them to targets, so unrelated Go map/list iteration order no longer registers as a spurious attribute change on every discovery cycle
 - fix: validate the crash-loop `signal` parameter and pass it to the fallback shell as a positional argument, preventing command injection into the target pod (the signal option list is a UI hint only and was not enforced)
 - fix: reject control characters in ingress request-matcher conditions (path/method/header), preventing injection of additional directives into the nginx/HAProxy ingress controller configuration
 

--- a/extcontainer/container_discovery.go
+++ b/extcontainer/container_discovery.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
 	"time"
 
@@ -185,6 +186,7 @@ func (c *containerDiscovery) DiscoverEnrichmentData(_ context.Context) ([]discov
 				for _, service := range services {
 					serviceNames = append(serviceNames, service.Name)
 				}
+				slices.Sort(serviceNames)
 				attributes["k8s.service.name"] = serviceNames
 			}
 

--- a/extnode/node_discovery.go
+++ b/extnode/node_discovery.go
@@ -6,6 +6,7 @@ package extnode
 import (
 	"context"
 	"reflect"
+	"slices"
 	"strings"
 	"time"
 
@@ -207,12 +208,15 @@ func (d *nodeDiscovery) DiscoverTargets(_ context.Context) ([]discovery_kit_api.
 			}
 
 			if len(containerIds) > 0 {
+				slices.Sort(containerIds)
 				attributes["k8s.container.id"] = containerIds
 			}
 			if len(containerIdsWithoutPrefix) > 0 {
+				slices.Sort(containerIdsWithoutPrefix)
 				attributes["k8s.container.id.stripped"] = containerIdsWithoutPrefix
 			}
 			if len(podNames) > 0 {
+				slices.Sort(podNames)
 				attributes["k8s.pod.name"] = podNames
 			}
 			if len(replicaSets) > 0 {
@@ -252,5 +256,6 @@ func keys(m map[string]bool) []string {
 		keys[i] = k
 		i++
 	}
+	slices.Sort(keys)
 	return keys
 }

--- a/extnode/node_discovery_test.go
+++ b/extnode/node_discovery_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/steadybit/discovery-kit/go/discovery_kit_api"
 	"github.com/steadybit/extension-kubernetes/v2/client"
 	"github.com/steadybit/extension-kubernetes/v2/extconfig"
 	"github.com/steadybit/extension-kubernetes/v2/testutil"
@@ -169,6 +170,84 @@ func Test_nodeDiscovery(t *testing.T) {
 		"k8s.node.label.label2":     {"value2"},
 		"k8s.node.label":            {"label1", "label2"},
 	}, target.Attributes)
+}
+
+func Test_nodeDiscovery_MultiValueAttributesAreSorted(t *testing.T) {
+	// Given
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	objects := []runtime.Object{
+		&v1.Node{
+			TypeMeta:   metav1.TypeMeta{Kind: "Node", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{Name: "node-123"},
+		},
+	}
+	// Deliberately named/created out of lexical order to make sure any accidental
+	// dependence on map/list iteration order would surface as a flaky assertion below.
+	podNames := []string{"zebra-pod", "mango-pod", "apple-pod"}
+	deploymentNames := []string{"zebra-deployment", "mango-deployment", "apple-deployment"}
+	serviceNames := []string{"zebra-service", "mango-service", "apple-service"}
+	containerIds := []string{"crio://zzz", "crio://mmm", "crio://aaa"}
+
+	for i := range podNames {
+		objects = append(objects,
+			&v1.Pod{
+				TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      podNames[i],
+					Namespace: "default",
+					Labels:    map[string]string{"app": deploymentNames[i]},
+					OwnerReferences: []metav1.OwnerReference{
+						{Kind: "Deployment", Name: deploymentNames[i]},
+					},
+				},
+				Status: v1.PodStatus{
+					Phase: v1.PodRunning,
+					ContainerStatuses: []v1.ContainerStatus{
+						{ContainerID: containerIds[i], Name: "app", Image: "nginx"},
+					},
+				},
+				Spec: v1.PodSpec{
+					NodeName:   "node-123",
+					Containers: []v1.Container{{Name: "app", Image: "nginx"}},
+				},
+			},
+			&appsv1.Deployment{
+				TypeMeta:   metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+				ObjectMeta: metav1.ObjectMeta{Name: deploymentNames[i], Namespace: "default"},
+			},
+			&v1.Service{
+				TypeMeta:   metav1.TypeMeta{Kind: "Service", APIVersion: "v1"},
+				ObjectMeta: metav1.ObjectMeta{Name: serviceNames[i], Namespace: "default"},
+				Spec:       v1.ServiceSpec{Selector: map[string]string{"app": deploymentNames[i]}},
+			},
+		)
+	}
+	client := getTestClient(stopCh, objects...)
+	extconfig.Config.ClusterName = "development"
+	extconfig.Config.LabelFilter = nil
+
+	d := &nodeDiscovery{k8s: client}
+
+	// When run repeatedly, the multi-value attributes must come back in the same,
+	// sorted order every time regardless of Go's randomized map iteration order.
+	for i := 0; i < 20; i++ {
+		var targets []discovery_kit_api.Target
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			var err error
+			targets, err = d.DiscoverTargets(context.Background())
+			require.NoError(c, err)
+			require.Len(c, targets, 1)
+		}, 5*time.Second, 100*time.Millisecond)
+
+		attrs := targets[0].Attributes
+		assert.Equal(t, []string{"apple-deployment", "mango-deployment", "zebra-deployment"}, attrs["k8s.deployment"])
+		assert.Equal(t, []string{"apple-service", "mango-service", "zebra-service"}, attrs["k8s.service.name"])
+		assert.Equal(t, []string{"apple-pod", "mango-pod", "zebra-pod"}, attrs["k8s.pod.name"])
+		assert.Equal(t, []string{"crio://aaa", "crio://mmm", "crio://zzz"}, attrs["k8s.container.id"])
+		assert.Equal(t, []string{"aaa", "mmm", "zzz"}, attrs["k8s.container.id.stripped"])
+		assert.Equal(t, []string{"default"}, attrs["k8s.namespace"])
+	}
 }
 
 func getTestClient(stopCh <-chan struct{}, objects ...runtime.Object) *client.Client {

--- a/extpod/pod_discovery.go
+++ b/extpod/pod_discovery.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
 	"time"
 
@@ -127,6 +128,7 @@ func (p *podDiscovery) DiscoverTargets(_ context.Context) ([]discovery_kit_api.T
 			for _, service := range services {
 				serviceNames = append(serviceNames, service.Name)
 			}
+			slices.Sort(serviceNames)
 			attributes["k8s.service.name"] = serviceNames
 		}
 		targetName := fmt.Sprintf("%s/%s/%s", extconfig.Config.ClusterName, pod.Namespace, pod.Name)


### PR DESCRIPTION
## Summary
- The `kubernetes-node` target's aggregated attributes (`k8s.container.id`, `k8s.container.id.stripped`, `k8s.pod.name`, `k8s.namespace`, `k8s.replicaset`, `k8s.deployment`, `k8s.daemonset`, `k8s.statefulset`, `k8s.service.name`) were built from Go maps/lister lists without any sort, so their order was non-deterministic across discovery cycles even when the underlying set of pods/workloads on the node hadn't changed.
- `k8s.service.name` on `kubernetes-container` and `kubernetes-pod` had the same bug — built by hand instead of going through the extension's shared, sorting `MergeAttributes`/`AddFilteredLabels` helpers.
- Because the platform's change-detection compares attribute values verbatim, this reordering registered as a real attribute change on every cycle, driving unnecessary target UPDATE + enrichment/reconciliation writes — a customer with a large, dynamic cluster observed this as sustained high-frequency `kubernetes-node` update churn.
- Fix: sort each slice before attaching it to the target, so identical content always compares equal regardless of map/list iteration order. Label-derived attributes (`k8s.label*`, `k8s.namespace.label*`, `k8s.node.label*`) were already safe — they route through `mergeAttributeValues`, which sorts+dedupes.

## Test plan
- [x] Added `Test_nodeDiscovery_MultiValueAttributesAreSorted`, which builds pods/deployments/services with intentionally out-of-lexical-order names and asserts sorted, stable output across repeated discovery calls — verified it fails without the fix and passes with it
- [x] `go test ./extnode/... ./extcontainer/... ./extpod/...` pass
- [x] `go test ./...` passes (only unrelated `e2e` package fails, due to no local Minikube available in this environment)