### PR TITLE
feat(pod count check): add fail early option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add a "Fail early" option to the pod count check. When enabled (the default, matching the previous behavior), the "All the time" mode fails as soon as the pod count condition is violated. When disabled, the check keeps collecting events for the whole duration and only fails at the end of the step. Only affects the "All the time" mode; "At least once" is unaffected.
+
 ## v2.6.29
 
 - feat: add flags to independently disable namespace/node/pod label inheritance during discovery

--- a/extcommon/pod_count_check.go
+++ b/extcommon/pod_count_check.go
@@ -69,11 +69,10 @@ type PodCountCheckState struct {
 	MetricLabelKey    string
 	InitialCount      int
 	LastMetrics       map[string]int32
-	// DeviationSeen and DeviationTitle are used in 'All the time' + fail-at-end mode (FailEarly =
-	// false) to remember that the condition was violated during the step so the failure can be
-	// reported once the step ends.
-	DeviationSeen  bool
-	DeviationTitle string
+	// DeviationError is set in 'All the time' + fail-at-end mode (FailEarly = false) to remember the
+	// first observed violation during the step (preserving its original status) so it can be reported
+	// once the step ends.
+	DeviationError *action_kit_api.ActionKitError
 }
 
 type PodCountCheckConfig struct {
@@ -355,20 +354,15 @@ func (f PodCountCheckAction) Status(_ context.Context, state *PodCountCheckState
 					Metrics:   metricsPtr,
 				}, nil
 			}
-			state.DeviationSeen = true
-			state.DeviationTitle = checkError.Title
+			// Remember the first violation (with its original status) to report at the end of the step.
+			if state.DeviationError == nil {
+				state.DeviationError = checkError
+			}
 		}
 		if now.After(state.Timeout) {
-			var endError *action_kit_api.ActionKitError
-			if state.DeviationSeen {
-				endError = new(action_kit_api.ActionKitError{
-					Title:  state.DeviationTitle,
-					Status: extutil.Ptr(action_kit_api.Failed),
-				})
-			}
 			return &action_kit_api.StatusResult{
 				Completed: true,
-				Error:     endError,
+				Error:     state.DeviationError,
 				Metrics:   metricsPtr,
 			}, nil
 		}

--- a/extcommon/pod_count_check.go
+++ b/extcommon/pod_count_check.go
@@ -63,11 +63,17 @@ type PodCountCheckState struct {
 	Timeout           time.Time
 	PodCountCheckMode CheckMode
 	StatusCheckMode   StatusCheckMode
+	FailEarly         bool
 	Namespace         string
 	Target            string
 	MetricLabelKey    string
 	InitialCount      int
 	LastMetrics       map[string]int32
+	// DeviationSeen and DeviationTitle are used in 'All the time' + fail-at-end mode (FailEarly =
+	// false) to remember that the condition was violated during the step so the failure can be
+	// reported once the step ends.
+	DeviationSeen  bool
+	DeviationTitle string
 }
 
 type PodCountCheckConfig struct {
@@ -167,6 +173,16 @@ func (f PodCountCheckAction) Describe() action_kit_api.ActionDescription {
 					},
 				}),
 			},
+			{
+				Name:         "failEarly",
+				Label:        "Fail early",
+				Description:  new("If enabled, the check fails as soon as the condition is violated. If disabled, the check keeps collecting events for the whole duration and only fails at the end of the step. Only affects the 'All the time' mode; 'At least once' can only be evaluated at the end of the step."),
+				Type:         action_kit_api.ActionParameterTypeBoolean,
+				DefaultValue: new("true"),
+				Advanced:     new(true),
+				Required:     new(false),
+				Order:        new(4),
+			},
 		},
 		Widgets: func() *[]action_kit_api.Widget {
 			if f.Widget == nil {
@@ -203,9 +219,16 @@ func (f PodCountCheckAction) Prepare(_ context.Context, state *PodCountCheckStat
 		statusCheckMode = StatusCheckModeAtLeastOnce
 	}
 
+	// Default to failing early to preserve the previous behavior for experiments that don't set this parameter.
+	failEarly := true
+	if request.Config["failEarly"] != nil {
+		failEarly = extutil.ToBool(request.Config["failEarly"])
+	}
+
 	state.Timeout = time.Now().Add(time.Millisecond * time.Duration(config.Duration))
 	state.PodCountCheckMode = config.PodCountCheckMode
 	state.StatusCheckMode = statusCheckMode
+	state.FailEarly = failEarly
 	state.Namespace = namespace
 	state.Target = target
 	state.MetricLabelKey = f.MetricLabelKey
@@ -293,7 +316,7 @@ func (f PodCountCheckAction) Status(_ context.Context, state *PodCountCheckState
 	// Determine whether this is the completing tick before deciding on metric emission.
 	completing := false
 	if state.StatusCheckMode == StatusCheckModeAllTheTime {
-		completing = checkError != nil || now.After(state.Timeout)
+		completing = (checkError != nil && state.FailEarly) || now.After(state.Timeout)
 	} else {
 		completing = checkError == nil || now.After(state.Timeout)
 	}
@@ -321,17 +344,36 @@ func (f PodCountCheckAction) Status(_ context.Context, state *PodCountCheckState
 	}()
 
 	if state.StatusCheckMode == StatusCheckModeAllTheTime {
-		// The condition must hold for the complete duration: fail fast on the first violation,
-		// otherwise keep checking until the duration has elapsed.
+		// The condition must hold for the complete duration. With fail early (default) the check fails
+		// fast on the first violation; otherwise it keeps collecting events and reports a violation
+		// only once the duration has elapsed.
 		if checkError != nil {
+			if state.FailEarly {
+				return &action_kit_api.StatusResult{
+					Completed: true,
+					Error:     checkError,
+					Metrics:   metricsPtr,
+				}, nil
+			}
+			state.DeviationSeen = true
+			state.DeviationTitle = checkError.Title
+		}
+		if now.After(state.Timeout) {
+			var endError *action_kit_api.ActionKitError
+			if state.DeviationSeen {
+				endError = new(action_kit_api.ActionKitError{
+					Title:  state.DeviationTitle,
+					Status: extutil.Ptr(action_kit_api.Failed),
+				})
+			}
 			return &action_kit_api.StatusResult{
 				Completed: true,
-				Error:     checkError,
+				Error:     endError,
 				Metrics:   metricsPtr,
 			}, nil
 		}
 		return &action_kit_api.StatusResult{
-			Completed: now.After(state.Timeout),
+			Completed: false,
 			Metrics:   metricsPtr,
 		}, nil
 	}

--- a/extcommon/pod_count_check_test.go
+++ b/extcommon/pod_count_check_test.go
@@ -183,6 +183,7 @@ func Test_statusPodCountCheckStatusCheckMode(t *testing.T) {
 	tests := []struct {
 		name            string
 		statusCheckMode StatusCheckMode
+		failEarly       bool
 		timeoutElapsed  bool
 		readyCount      int
 		desiredCount    int
@@ -235,9 +236,30 @@ func Test_statusPodCountCheckStatusCheckMode(t *testing.T) {
 			wantError:       false,
 		},
 		{
-			name:            "allTheTime fails fast when condition is violated",
+			name:            "allTheTime with fail early fails fast when condition is violated",
 			statusCheckMode: StatusCheckModeAllTheTime,
+			failEarly:       true,
 			timeoutElapsed:  false,
+			readyCount:      1,
+			desiredCount:    2,
+			wantCompleted:   true,
+			wantError:       true,
+		},
+		{
+			name:            "allTheTime without fail early keeps running on violation before timeout",
+			statusCheckMode: StatusCheckModeAllTheTime,
+			failEarly:       false,
+			timeoutElapsed:  false,
+			readyCount:      1,
+			desiredCount:    2,
+			wantCompleted:   false,
+			wantError:       false,
+		},
+		{
+			name:            "allTheTime without fail early reports the violation once the duration has elapsed",
+			statusCheckMode: StatusCheckModeAllTheTime,
+			failEarly:       false,
+			timeoutElapsed:  true,
 			readyCount:      1,
 			desiredCount:    2,
 			wantCompleted:   true,
@@ -264,6 +286,7 @@ func Test_statusPodCountCheckStatusCheckMode(t *testing.T) {
 				Timeout:           timeout,
 				PodCountCheckMode: PodCountEqualsDesiredCount,
 				StatusCheckMode:   tt.statusCheckMode,
+				FailEarly:         tt.failEarly,
 				Namespace:         "shop",
 				Target:            "checkout",
 			}


### PR DESCRIPTION
## Problem

The ending time of our checks isn't consistently applied, which makes experiments hard to time. This adds the per-check "fail early / fail at end" option, following the reference implementation in `extension-datadog`.

## Change

Adds a **`failEarly` boolean** to the shared pod count check (used by the deployment, statefulset, daemonset and replicaset pod-count checks):

- **Enabled (default)** — in `All the time` mode the check fails fast as soon as the pod count condition is violated (today's behavior).
- **Disabled** — the check keeps collecting events for the whole step duration and only fails at the end, remembering the violation via `DeviationSeen`/`DeviationTitle`.

Details:
- Parameter lives in the **Advanced** section, is **optional**, and defaults to `true` both in its description and in `Prepare`, so **existing experiments are non-breaking**.
- Only affects `All the time`. `At least once` (succeed as soon as the condition is met) is unchanged.

## Scope note — node count & rollout checks intentionally excluded

`Node Count` and `Deployment Rollout Status` are *wait-for-target-state* checks: they succeed as soon as the target is reached and only fail at the timeout. Their failure is inherently reported at the end, and a literal "fail early" (fail on the first poll the target isn't met yet) would break the wait semantics (e.g. failing before a scale-up/rollout has a chance to happen). So they are deliberately left unchanged.

## Tests

- Extended `Test_statusPodCountCheckStatusCheckMode` with a `failEarly` dimension: fail-early fast-fails on violation; fail-at-end keeps running before the timeout and reports the violation once the duration elapses.
- Set `failEarly: true` on the existing fast-fail case to preserve its intent.
- All pod-count consumer packages (deployment/statefulset/daemonset/replicaset) pass; `go vet` clean.