### PR TITLE
fix: show workload owner column for pods instead of joined fallback labels

### DIFF
--- a/extcommon/attributes.go
+++ b/extcommon/attributes.go
@@ -83,6 +83,20 @@ func (a *attributeDescriber) DescribeAttributes() []discovery_kit_api.AttributeD
 			},
 		},
 		{
+			Attribute: "k8s.workload-owner",
+			Label: discovery_kit_api.PluralLabel{
+				One:   "Workload owner",
+				Other: "Workload owners",
+			},
+		},
+		{
+			Attribute: "k8s.workload-type",
+			Label: discovery_kit_api.PluralLabel{
+				One:   "Workload type",
+				Other: "Workload types",
+			},
+		},
+		{
 			Attribute: LivenessProbePathAttribute,
 			Label: discovery_kit_api.PluralLabel{
 				One:   "Liveness probe path",

--- a/extpod/pod_discovery.go
+++ b/extpod/pod_discovery.go
@@ -59,7 +59,7 @@ func (*podDiscovery) DescribeTarget() discovery_kit_api.TargetDescription {
 				{Attribute: "k8s.pod.name"},
 				{Attribute: "k8s.cluster-name"},
 				{Attribute: "k8s.namespace"},
-				{Attribute: "k8s.deployment", FallbackAttributes: new([]string{"k8s.statefulset", "k8s.daemonset", "k8s.argo-rollout"})},
+				{Attribute: "k8s.workload-owner"},
 			},
 			OrderBy: []discovery_kit_api.OrderBy{
 				{


### PR DESCRIPTION
## What

Replaces the Kubernetes pod target table's last column — `k8s.deployment` with `k8s.statefulset` / `k8s.daemonset` / `k8s.argo-rollout` fallbacks — with the single `k8s.workload-owner` attribute, and registers human-readable labels for `k8s.workload-owner` and `k8s.workload-type`.

## Why

The platform joins the labels of a column's attribute and all fallbacks into one header, so pods showed **"Deployment name / StatefulSet name / DaemonSet name"** — an absurdly wide header that squeezes out the data columns in narrow views such as the experiment designer's target preview.

`k8s.workload-owner` is already populated from the owner-reference chain (top-most owner wins), so the column shows the same value as before for Deployment/StatefulSet/DaemonSet/Rollout-owned pods — and additionally covers Job/CronJob-owned pods, which rendered an empty cell before. Naked pods stay empty, as before.

Ticket: https://steadybitgmbh.kanbanize.com/ctrl_board/2/cards/19864

🤖 Generated with [Claude Code](https://claude.com/claude-code)