### PR TITLE
fix: emit the pod count metric immediately on Start

### DIFF
--- a/extcommon/pod_count_check.go
+++ b/extcommon/pod_count_check.go
@@ -236,8 +236,17 @@ func (f PodCountCheckAction) Prepare(_ context.Context, state *PodCountCheckStat
 	return nil, nil
 }
 
-func (f PodCountCheckAction) Start(_ context.Context, _ *PodCountCheckState) (*action_kit_api.StartResult, error) {
-	return nil, nil
+func (f PodCountCheckAction) Start(ctx context.Context, state *PodCountCheckState) (*action_kit_api.StartResult, error) {
+	statusResult, err := f.Status(ctx, state)
+	if statusResult == nil {
+		return nil, err
+	}
+	return &action_kit_api.StartResult{
+		Artifacts: statusResult.Artifacts,
+		Error:     statusResult.Error,
+		Messages:  statusResult.Messages,
+		Metrics:   statusResult.Metrics,
+	}, err
 }
 
 func (f PodCountCheckAction) Status(_ context.Context, state *PodCountCheckState) (*action_kit_api.StatusResult, error) {


### PR DESCRIPTION
## Summary
- `PodCountCheckAction.Start()` was a no-op, so the first pod-count metric (emitted only when a caller wires up `GetPodCountMetrics` — currently `extdeployment` and `extstatefulset`) only appeared after the first `Status()` poll (one `CallInterval`, i.e. 1s, after the check started).
- `Start()` now calls the same `Status()` method, so the first metric is emitted immediately when the check starts. This is shared code, so it also affects `extdaemonset`/`extreplicaset`'s pod-count checks (which don't wire up `GetPodCountMetrics`, so no behavior change there beyond fail-early potentially triggering at Start instead of the first poll).

## Test plan
- [x] `go build ./...`
- [x] `go test ./extcommon/... ./extdeployment/... ./extstatefulset/... ./extdaemonset/... ./extreplicaset/...`